### PR TITLE
made SSO display name configurable

### DIFF
--- a/.env.vagrant
+++ b/.env.vagrant
@@ -4,7 +4,9 @@ BIND=0.0.0.0
 DB_HOST=/var/run/postgresql/
 AUTHORIZED_FETCH=true
 MAX_STATUS_CHARS=3000
+
 OIDC_ENABLED=true
+OIDC_DISPLAY_NAME=phantauth
 OIDC_ISSUER=https://phantauth.net
 OIDC_DISCOVERY=true
 OIDC_SCOPE=openid,profile,email

--- a/app/views/auth/sessions/new.html.haml
+++ b/app/views/auth/sessions/new.html.haml
@@ -22,6 +22,6 @@
 
     .actions
       - resource_class.omniauth_providers.each do |provider|
-        = link_to t("auth.providers.#{Devise.omniauth_configs[provider].strategy.display_name}", default: Devise.omniauth_configs[provider].strategy.display_name.to_s.chomp("_oauth2").capitalize), omniauth_authorize_path(:user, provider), class: "button button-#{Devise.omniauth_configs[provider].strategy.display_name}", method: :post
+        = link_to t("auth.providers.#{Devise.omniauth_configs[provider].strategy.display_name}", default: Devise.omniauth_configs[provider].strategy.display_name.to_s.chomp("_oauth2").capitalize), omniauth_authorize_path(resource_name, provider), class: "button button-#{Devise.omniauth_configs[provider].strategy.display_name}", method: :post
 
 .form-footer= render 'auth/shared/links'

--- a/app/views/auth/sessions/new.html.haml
+++ b/app/views/auth/sessions/new.html.haml
@@ -22,6 +22,6 @@
 
     .actions
       - resource_class.omniauth_providers.each do |provider|
-        = link_to t("auth.providers.#{provider}", default: provider.to_s.chomp("_oauth2").capitalize), omniauth_authorize_path(resource_name, provider), class: "button button-#{provider}", method: :post
+        = link_to t("auth.providers.#{Devise.omniauth_configs[provider].strategy.display_name}", default: Devise.omniauth_configs[provider].strategy.display_name.to_s.chomp("_oauth2").capitalize), omniauth_authorize_path(:user, provider), class: "button button-#{Devise.omniauth_configs[provider].strategy.display_name}", method: :post
 
 .form-footer= render 'auth/shared/links'

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -4,12 +4,12 @@ end
 
 Devise.setup do |config|
   # Devise omniauth strategies
-  options = {}
-  options[:redirect_at_sign_in] = ENV['OAUTH_REDIRECT_AT_SIGN_IN'] == 'true'
 
   # CAS strategy
   if ENV['CAS_ENABLED'] == 'true'
-    cas_options = options
+    cas_options = {}
+    cas_options[:redirect_at_sign_in] = ENV['OAUTH_REDIRECT_AT_SIGN_IN'] == 'true'
+    cas_options[:display_name] = ENV['CAS_DISPLAY_NAME'] || 'cas'
     cas_options[:url] = ENV['CAS_URL'] if ENV['CAS_URL']
     cas_options[:host] = ENV['CAS_HOST'] if ENV['CAS_HOST']
     cas_options[:port] = ENV['CAS_PORT'] if ENV['CAS_PORT']
@@ -35,7 +35,9 @@ Devise.setup do |config|
 
   # SAML strategy
   if ENV['SAML_ENABLED'] == 'true'
-    saml_options = options
+    saml_options = {}
+    saml_options[:redirect_at_sign_in] = ENV['OAUTH_REDIRECT_AT_SIGN_IN'] == 'true'
+    saml_options[:display_name] = ENV['SAML_DISPLAY_NAME'] || 'saml'
     saml_options[:assertion_consumer_service_url] = ENV['SAML_ACS_URL'] if ENV['SAML_ACS_URL']
     saml_options[:issuer] = ENV['SAML_ISSUER'] if ENV['SAML_ISSUER']
     saml_options[:idp_sso_target_url] = ENV['SAML_IDP_SSO_TARGET_URL'] if ENV['SAML_IDP_SSO_TARGET_URL']
@@ -65,7 +67,9 @@ Devise.setup do |config|
 
   # OpenID Connect Strategy
   if ENV['OIDC_ENABLED'] == 'true'
-    oidc_options = options
+    oidc_options = {}
+    oidc_options[:redirect_at_sign_in] = ENV['OAUTH_REDIRECT_AT_SIGN_IN'] == 'true'
+    oidc_options[:display_name] = ENV['OIDC_DISPLAY_NAME'] || 'openid_connect' #OPTIONAL
     oidc_options[:name] = ENV['OIDC_PROVIDER_NAME'] if ENV['OIDC_PROVIDER_NAME'] #OPTIONAL (default: openid_connect)
     oidc_options[:issuer] = ENV['OIDC_ISSUER'] if ENV['OIDC_ISSUER'] #NEED
     oidc_options[:discovery] = ENV['OIDC_DISCOVERY'] if ENV['OIDC_DISCOVERY'] #OPTIONAL (default: false)


### PR DESCRIPTION
Also addresses bug that arises when you have multiple SSO providers. Reference variable "options" in omniauth.rb overwrites the other providers' dicts. "options" was introduced in https://github.com/tootsuite/mastodon/pull/6540 