### PR TITLE
Make it so SSO users still have to be approved if the instance has closed registration.

### DIFF
--- a/app/controllers/auth/setup_controller.rb
+++ b/app/controllers/auth/setup_controller.rb
@@ -13,7 +13,11 @@ class Auth::SetupController < ApplicationController
   def show
     flash.now[:notice] = begin
       if @user.pending?
-        I18n.t('devise.registrations.signed_up_but_pending')
+        if @user.confirmed?
+          "We will review your application. You will be notified if it is approved."
+        else
+          I18n.t('devise.registrations.signed_up_but_pending')
+        end
       else
         I18n.t('devise.registrations.signed_up_but_unconfirmed')
       end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -412,7 +412,7 @@ class User < ApplicationRecord
       if sign_up_from_ip_requires_approval?
         false
       else
-        open_registrations? || valid_invitation? || external?
+        open_registrations? || valid_invitation?
       end
     end
   end


### PR DESCRIPTION
Rolls back https://github.com/tootsuite/mastodon/pull/10621