### PR TITLE
UI simplification; made direct messages configurable in whitelist_mode

### DIFF
--- a/app/javascript/mastodon/components/status_action_bar.js
+++ b/app/javascript/mastodon/components/status_action_bar.js
@@ -6,7 +6,7 @@ import IconButton from './icon_button';
 import DropdownMenuContainer from '../containers/dropdown_menu_container';
 import { defineMessages, injectIntl } from 'react-intl';
 import ImmutablePureComponent from 'react-immutable-pure-component';
-import { me, isStaff, whitelistMode } from '../initial_state';
+import { me, isStaff, whitelistMode, dmsEnabled } from '../initial_state';
 import classNames from 'classnames';
 
 const messages = defineMessages({
@@ -254,7 +254,7 @@ class StatusActionBar extends ImmutablePureComponent {
       menu.push({ text: intl.formatMessage(messages.redraft), action: this.handleRedraftClick });
     } else {
       menu.push({ text: intl.formatMessage(messages.mention, { name: account.get('username') }), action: this.handleMentionClick });
-      menu.push({ text: intl.formatMessage(messages.direct, { name: account.get('username') }), action: this.handleDirectClick });
+      if (dmsEnabled) { menu.push({ text: intl.formatMessage(messages.direct, { name: account.get('username') }), action: this.handleDirectClick }); }
       menu.push(null);
 
       if (relationship && relationship.get('muting')) {

--- a/app/javascript/mastodon/features/account/components/header.js
+++ b/app/javascript/mastodon/features/account/components/header.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
 import Button from 'mastodon/components/button';
 import ImmutablePureComponent from 'react-immutable-pure-component';
-import { autoPlayGif, me, isStaff, showStaffBadge, whitelistMode } from 'mastodon/initial_state';
+import { autoPlayGif, me, isStaff, showStaffBadge, whitelistMode, dmsEnabled } from 'mastodon/initial_state';
 import classNames from 'classnames';
 import Icon from 'mastodon/components/icon';
 import IconButton from 'mastodon/components/icon_button';
@@ -192,7 +192,7 @@ class Header extends ImmutablePureComponent {
 
     if (account.get('id') !== me) {
       menu.push({ text: intl.formatMessage(messages.mention, { name: account.get('username') }), action: this.props.onMention });
-      menu.push({ text: intl.formatMessage(messages.direct, { name: account.get('username') }), action: this.props.onDirect });
+      if (dmsEnabled) { menu.push({ text: intl.formatMessage(messages.direct, { name: account.get('username') }), action: this.props.onDirect }); }
       menu.push(null);
     }
 

--- a/app/javascript/mastodon/features/compose/components/privacy_dropdown.js
+++ b/app/javascript/mastodon/features/compose/components/privacy_dropdown.js
@@ -8,6 +8,7 @@ import spring from 'react-motion/lib/spring';
 import { supportsPassiveEvents } from 'detect-passive-events';
 import classNames from 'classnames';
 import Icon from 'mastodon/components/icon';
+import { whitelistMode, dmsEnabled } from '../../../initial_state';
 
 const messages = defineMessages({
   public_short: { id: 'privacy.public.short', defaultMessage: 'Public' },
@@ -234,9 +235,9 @@ class PrivacyDropdown extends React.PureComponent {
 
     this.options = [
       { icon: 'globe', value: 'public', text: formatMessage(messages.public_short), meta: formatMessage(messages.public_long) },
-      { icon: 'unlock', value: 'unlisted', text: formatMessage(messages.unlisted_short), meta: formatMessage(messages.unlisted_long) },
-      { icon: 'lock', value: 'private', text: formatMessage(messages.private_short), meta: formatMessage(messages.private_long) },
-      { icon: 'envelope', value: 'direct', text: formatMessage(messages.direct_short), meta: formatMessage(messages.direct_long) },
+      ... whitelistMode ? [] : [{ icon: 'unlock', value: 'unlisted', text: formatMessage(messages.unlisted_short), meta: formatMessage(messages.unlisted_long) }],
+      ... whitelistMode ? [] : [{ icon: 'lock', value: 'private', text: formatMessage(messages.private_short), meta: formatMessage(messages.private_long) }],
+      ... dmsEnabled ? [{ icon: 'envelope', value: 'direct', text: formatMessage(messages.direct_short), meta: formatMessage(messages.direct_long) }] : [],
     ];
   }
 

--- a/app/javascript/mastodon/features/getting_started/index.js
+++ b/app/javascript/mastodon/features/getting_started/index.js
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
-import { me, profile_directory, showTrends, completelySiloed, whitelistMode } from '../../initial_state';
+import { me, profile_directory, showTrends, completelySiloed, whitelistMode, dmsEnabled } from '../../initial_state';
 import { fetchFollowRequests } from 'mastodon/actions/accounts';
 import { List as ImmutableList } from 'immutable';
 import NavigationContainer from '../compose/containers/navigation_container';
@@ -133,7 +133,7 @@ class GettingStarted extends ImmutablePureComponent {
     }
 
     navItems.push(
-      <ColumnLink key='direct' icon='envelope' text={intl.formatMessage(messages.direct)} to='/timelines/direct' />,
+      ... dmsEnabled ? [<ColumnLink key='direct' icon='envelope' text={intl.formatMessage(messages.direct)} to='/timelines/direct' />] : [],
       ... whitelistMode ? [] : [<ColumnLink key='bookmark' icon='bookmark' text={intl.formatMessage(messages.bookmarks)} to='/bookmarks' />],
       <ColumnLink key='favourites' icon='star' text={intl.formatMessage(messages.favourites)} to='/favourites' />,
       ... whitelistMode ? [] : [<ColumnLink key='lists' icon='list-ul' text={intl.formatMessage(messages.lists)} to='/lists' />],

--- a/app/javascript/mastodon/features/status/components/action_bar.js
+++ b/app/javascript/mastodon/features/status/components/action_bar.js
@@ -5,7 +5,7 @@ import IconButton from '../../../components/icon_button';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import DropdownMenuContainer from '../../../containers/dropdown_menu_container';
 import { defineMessages, injectIntl } from 'react-intl';
-import { me, isStaff, whitelistMode } from '../../../initial_state';
+import { me, isStaff, whitelistMode, dmsEnabled } from '../../../initial_state';
 import classNames from 'classnames';
 
 const messages = defineMessages({
@@ -211,7 +211,7 @@ class ActionBar extends React.PureComponent {
       menu.push({ text: intl.formatMessage(messages.redraft), action: this.handleRedraftClick });
     } else {
       menu.push({ text: intl.formatMessage(messages.mention, { name: status.getIn(['account', 'username']) }), action: this.handleMentionClick });
-      menu.push({ text: intl.formatMessage(messages.direct, { name: status.getIn(['account', 'username']) }), action: this.handleDirectClick });
+      if (dmsEnabled) { menu.push({ text: intl.formatMessage(messages.direct, { name: status.getIn(['account', 'username']) }), action: this.handleDirectClick }); }
       menu.push(null);
 
       if (relationship && relationship.get('muting')) {

--- a/app/javascript/mastodon/features/ui/components/link_footer.js
+++ b/app/javascript/mastodon/features/ui/components/link_footer.js
@@ -51,10 +51,7 @@ class LinkFooter extends React.PureComponent {
           {withHotkeys && <li><Link to='/keyboard-shortcuts'><FormattedMessage id='navigation_bar.keyboard_shortcuts' defaultMessage='Hotkeys' /></Link> · </li>}
           <li><a href='/auth/edit'><FormattedMessage id='getting_started.security' defaultMessage='Security' /></a> · </li>
           <li><a href='/about/more' target='_blank'><FormattedMessage id='navigation_bar.info' defaultMessage='About this server' /></a> · </li>
-          <li><a href='https://joinmastodon.org/apps' target='_blank'><FormattedMessage id='navigation_bar.apps' defaultMessage='Mobile apps' /></a> · </li>
           <li><a href='/terms' target='_blank'><FormattedMessage id='getting_started.terms' defaultMessage='Terms of service' /></a> · </li>
-          <li><a href='/settings/applications' target='_blank'><FormattedMessage id='getting_started.developers' defaultMessage='Developers' /></a> · </li>
-          <li><a href='https://docs.joinmastodon.org' target='_blank'><FormattedMessage id='getting_started.documentation' defaultMessage='Documentation' /></a> · </li>
           <li><a href='/auth/sign_out' onClick={this.handleLogoutClick}><FormattedMessage id='navigation_bar.logout' defaultMessage='Logout' /></a></li>
         </ul>
 

--- a/app/javascript/mastodon/features/ui/components/navigation_panel.js
+++ b/app/javascript/mastodon/features/ui/components/navigation_panel.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { NavLink, withRouter } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 import Icon from 'mastodon/components/icon';
-import { profile_directory, showTrends, completelySiloed, whitelistMode } from 'mastodon/initial_state';
+import { profile_directory, showTrends, completelySiloed, whitelistMode, dmsEnabled } from 'mastodon/initial_state';
 import NotificationsCounterIcon from './notifications_counter_icon';
 import FollowRequestsNavLink from './follow_requests_nav_link';
 import ListPanel from './list_panel';
@@ -20,7 +20,7 @@ const NavigationPanel = () => (
     <NavLink className='column-link column-link--transparent' to='/notifications' data-preview-title-id='column.notifications' data-preview-icon='bell' ><NotificationsCounterIcon className='column-link__icon' /><FormattedMessage id='tabs_bar.notifications' defaultMessage='Notifications' /></NavLink>
     <FollowRequestsNavLink />
     {!whitelistMode && localAndFederated}
-    <NavLink className='column-link column-link--transparent' to='/timelines/direct'><Icon className='column-link__icon' id='envelope' fixedWidth /><FormattedMessage id='navigation_bar.direct' defaultMessage='Direct messages' /></NavLink>
+    {dmsEnabled && <NavLink className='column-link column-link--transparent' to='/timelines/direct'><Icon className='column-link__icon' id='envelope' fixedWidth /><FormattedMessage id='navigation_bar.direct' defaultMessage='Direct messages' /></NavLink>}
     <NavLink className='column-link column-link--transparent' to='/favourites'><Icon className='column-link__icon' id='star' fixedWidth /><FormattedMessage id='navigation_bar.favourites' defaultMessage='Favourites' /></NavLink>
     {!whitelistMode && <NavLink className='column-link column-link--transparent' to='/bookmarks'><Icon className='column-link__icon' id='bookmark' fixedWidth /><FormattedMessage id='navigation_bar.bookmarks' defaultMessage='Bookmarks' /></NavLink>}
     {!whitelistMode && <NavLink className='column-link column-link--transparent' to='/lists'><Icon className='column-link__icon' id='list-ul' fixedWidth /><FormattedMessage id='navigation_bar.lists' defaultMessage='Lists' /></NavLink>}

--- a/app/javascript/mastodon/initial_state.js
+++ b/app/javascript/mastodon/initial_state.js
@@ -29,5 +29,6 @@ export const disableSwiping = getMeta('disable_swiping');
 export const showStaffBadge = getMeta('show_staff_badge');
 export const completelySiloed = getMeta('completely_siloed');
 export const whitelistMode = getMeta('whitelist_mode');
+export const dmsEnabled = getMeta('dms_enabled');
 
 export default initialState;

--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -36,6 +36,7 @@ class Form::AdminSettings
     show_domain_blocks_rationale
     noindex
     require_invite_text
+    dms_enabled
   ).freeze
 
   BOOLEAN_KEYS = %i(
@@ -53,6 +54,7 @@ class Form::AdminSettings
     trendable_by_default
     noindex
     require_invite_text
+    dms_enabled
   ).freeze
 
   UPLOAD_KEYS = %i(

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -270,7 +270,10 @@ class Status < ApplicationRecord
 
   class << self
     def selectable_visibilities
-      visibilities.keys - %w(direct limited)
+      selectable = visibilities.keys - %w(direct limited)
+      if Rails.configuration.x.whitelist_mode
+        selectable = visibilities.keys - %w(direct limited private unlisted)
+      end
     end
 
     def favourites_map(status_ids, account_id)

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -29,6 +29,7 @@ class InitialStateSerializer < ActiveModel::Serializer
       show_staff_badge: Setting.show_staff_badge,
       completely_siloed: Rails.configuration.x.whitelist_mode && DomainAllow.count() == 0,
       whitelist_mode: Rails.configuration.x.whitelist_mode,
+      dms_enabled: Setting.dms_enabled,
     }
 
     if object.current_account

--- a/app/views/about/more.html.haml
+++ b/app/views/about/more.html.haml
@@ -14,15 +14,16 @@
   .column-1
     .landing-page__call-to-action{ dir: 'ltr' }
       .row
-        .row__information-board
-          .information-board__section
-            %span= t 'about.user_count_before'
-            %strong= number_to_human @instance_presenter.user_count, strip_insignificant_zeros: true
-            %span= t 'about.user_count_after', count: @instance_presenter.user_count
-          .information-board__section
-            %span= t 'about.status_count_before'
-            %strong= number_to_human @instance_presenter.status_count, strip_insignificant_zeros: true
-            %span= t 'about.status_count_after', count: @instance_presenter.status_count
+        - if !whitelist_mode?
+          .row__information-board
+            .information-board__section
+              %span= t 'about.user_count_before'
+              %strong= number_to_human @instance_presenter.user_count, strip_insignificant_zeros: true
+              %span= t 'about.user_count_after', count: @instance_presenter.user_count
+            .information-board__section
+              %span= t 'about.status_count_before'
+              %strong= number_to_human @instance_presenter.status_count, strip_insignificant_zeros: true
+              %span= t 'about.status_count_after', count: @instance_presenter.status_count
         .row__mascot
           .landing-page__mascot
             = image_tag @instance_presenter.mascot&.file&.url || asset_pack_path('media/images/elephant_ui_plane.svg'), alt: ''

--- a/app/views/about/show.html.haml
+++ b/app/views/about/show.html.haml
@@ -37,12 +37,13 @@
                 = t('about.see_whats_happening')
                 %small= t('about.browse_public_posts')
 
-        .directory__tag
-          = link_to 'https://joinmastodon.org/apps', target: '_blank', rel: 'noopener noreferrer' do
-            %h4
-              = fa_icon 'tablet fw'
-              = t('about.get_apps')
-              %small= t('about.apps_platforms')
+        - if !whitelist_mode?
+          .directory__tag
+            = link_to 'https://joinmastodon.org/apps', target: '_blank', rel: 'noopener noreferrer' do
+              %h4
+                = fa_icon 'tablet fw'
+                = t('about.get_apps')
+                %small= t('about.apps_platforms')
 
     .landing__grid__column.landing__grid__column-login
       .box-widget
@@ -59,21 +60,22 @@
               = t('about.learn_more')
               = fa_icon 'angle-double-right'
 
-        .hero-widget__footer
-          .hero-widget__footer__column
-            %h4= t 'about.administered_by'
+        - if !whitelist_mode?
+          .hero-widget__footer
+            .hero-widget__footer__column
+              %h4= t 'about.administered_by'
 
-            = account_link_to @instance_presenter.contact_account
+              = account_link_to @instance_presenter.contact_account
 
-          .hero-widget__footer__column
-            %h4= t 'about.server_stats'
+            .hero-widget__footer__column
+              %h4= t 'about.server_stats'
 
-            .hero-widget__counters__wrapper
-              .hero-widget__counter
-                %strong= number_to_human @instance_presenter.user_count, strip_insignificant_zeros: true
-                %span= t 'about.user_count_after', count: @instance_presenter.user_count
-              .hero-widget__counter
-                %strong= number_to_human @instance_presenter.active_user_count, strip_insignificant_zeros: true
-                %span
-                  = t 'about.active_count_after'
-                  %abbr{ title: t('about.active_footnote') } *
+              .hero-widget__counters__wrapper
+                .hero-widget__counter
+                  %strong= number_to_human @instance_presenter.user_count, strip_insignificant_zeros: true
+                  %span= t 'about.user_count_after', count: @instance_presenter.user_count
+                .hero-widget__counter
+                  %strong= number_to_human @instance_presenter.active_user_count, strip_insignificant_zeros: true
+                  %span
+                    = t 'about.active_count_after'
+                    %abbr{ title: t('about.active_footnote') } *

--- a/app/views/admin/settings/edit.html.haml
+++ b/app/views/admin/settings/edit.html.haml
@@ -63,6 +63,10 @@
 
     .fields-group
       = f.input :show_known_fediverse_at_about_page, as: :boolean, wrapper: :with_label, label: t('admin.settings.show_known_fediverse_at_about_page.title'), hint: t('admin.settings.show_known_fediverse_at_about_page.desc_html')
+  
+  - if whitelist_mode?
+    .fields-group
+      = f.input :dms_enabled, as: :boolean, wrapper: :with_label, label: "Enable direct messages", hint: "Allow users to send direct messages"
 
   .fields-group
     = f.input :show_staff_badge, as: :boolean, wrapper: :with_label, label: t('admin.settings.show_staff_badge.title'), hint: t('admin.settings.show_staff_badge.desc_html')

--- a/app/views/layouts/public.html.haml
+++ b/app/views/layouts/public.html.haml
@@ -35,23 +35,13 @@
             %ul
               %li= link_to t('about.terms'), terms_path
               %li= link_to t('about.privacy_policy'), terms_path
-          .column-1
-            %h4= t 'footer.developers'
-            %ul
-              %li= link_to t('about.documentation'), 'https://docs.joinmastodon.org/'
-              %li= link_to t('about.api'), 'https://docs.joinmastodon.org/client/intro/'
           .column-2
             %h4= link_to t('about.what_is_mastodon'), 'https://joinmastodon.org/'
             = link_to svg_logo, root_url, class: 'brand'
-          .column-3
+          .column-4
             %h4= site_hostname
             %ul
               %li= link_to t('about.about_this'), about_more_path
-              %li= "v#{Mastodon::Version.to_s}"
-          .column-4
-            %h4= t 'footer.more'
-            %ul
               %li= link_to t('about.source_code'), Mastodon::Version.source_url
-              %li= link_to t('about.apps'), 'https://joinmastodon.org/apps'
 
 = render template: 'layouts/application'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -71,6 +71,7 @@ defaults: &defaults
   show_domain_blocks: 'disabled'
   show_domain_blocks_rationale: 'disabled'
   require_invite_text: false
+  dms_enabled: true
 
 development:
   <<: *defaults


### PR DESCRIPTION
- Reduced types of posts to "public" and "direct" in whitelist_mode, removing "unlisted" and "private"
- Made direct message functionality configurable through the admin dashboard in whitelist_mode (enabled by default)
- Removed footer links 
- Removed user stats from about pages in whitelist_mode
- Removed about footer from /about in whitelist_mode