### PR TITLE
made development tab configurable in whitelist_mode

### DIFF
--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -37,6 +37,7 @@ class Form::AdminSettings
     noindex
     require_invite_text
     dms_enabled
+    non_staff_development
   ).freeze
 
   BOOLEAN_KEYS = %i(
@@ -55,6 +56,7 @@ class Form::AdminSettings
     noindex
     require_invite_text
     dms_enabled
+    non_staff_development
   ).freeze
 
   UPLOAD_KEYS = %i(

--- a/app/views/admin/settings/edit.html.haml
+++ b/app/views/admin/settings/edit.html.haml
@@ -66,7 +66,11 @@
   
   - if completely_siloed?
     .fields-group
-      = f.input :dms_enabled, as: :boolean, wrapper: :with_label, label: "Enable direct messages", hint: "Allow users to send direct messages"
+      = f.input :dms_enabled, as: :boolean, wrapper: :with_label, label: t('admin.settings.dms_enabled.title'), hint: t('admin.settings.dms_enabled.desc_html')
+
+  - if whitelist_mode?
+    .fields-group
+      = f.input :non_staff_development, as: :boolean, wrapper: :with_label, label: t('admin.settings.non_staff_development.title'), hint: t('admin.settings.non_staff_development.desc_html')
 
   .fields-group
     = f.input :show_staff_badge, as: :boolean, wrapper: :with_label, label: t('admin.settings.show_staff_badge.title'), hint: t('admin.settings.show_staff_badge.desc_html')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -639,6 +639,12 @@ en:
       trends:
         desc_html: Publicly display previously reviewed hashtags that are currently trending
         title: Trending hashtags
+      dms_enabled:
+        desc_html: Allow users to send direct messages
+        title: Enable direct messages
+      non_staff_development:
+        desc_html: Allow non-staff users to create applications with API access through the UI
+        title: Enable the development tab for non-staff
     site_uploads:
       delete: Delete uploaded file
       destroyed_msg: Site upload successfully deleted!

--- a/config/navigation.rb
+++ b/config/navigation.rb
@@ -31,7 +31,7 @@ SimpleNavigation::Configuration.run do |navigation|
     end
 
     n.item :invites, safe_join([fa_icon('user-plus fw'), t('invites.title')]), invites_path, if: proc { Setting.min_invite_role == 'user' && current_user.functional? }
-    n.item :development, safe_join([fa_icon('code fw'), t('settings.development')]), settings_applications_url, if: -> { current_user.functional? }
+    n.item :development, safe_join([fa_icon('code fw'), t('settings.development')]), settings_applications_url, if: -> { current_user.functional? && (Setting.non_staff_development || current_user.staff?) }
 
     n.item :moderation, safe_join([fa_icon('gavel fw'), t('moderation.title')]), admin_reports_url, if: proc { current_user.staff? } do |s|
       s.item :action_logs, safe_join([fa_icon('bars fw'), t('admin.action_logs.title')]), admin_action_logs_url

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -72,6 +72,7 @@ defaults: &defaults
   show_domain_blocks_rationale: 'disabled'
   require_invite_text: false
   dms_enabled: true
+  non_staff_development: true
 
 development:
   <<: *defaults


### PR DESCRIPTION
- Makes the "Development" tab configurable in admin "Site settings" in whitelist_mode
- Setting non_staff_development to false removes the development tab for all users who aren't staff.  Default for non_staff_development is true. Non-staff can still create applications through the API when non_staff_development is false.