### PR TITLE
made featured hashtags configurable in whitelist_mode

### DIFF
--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -38,6 +38,7 @@ class Form::AdminSettings
     require_invite_text
     dms_enabled
     non_staff_development
+    featured_tags
   ).freeze
 
   BOOLEAN_KEYS = %i(
@@ -57,6 +58,7 @@ class Form::AdminSettings
     require_invite_text
     dms_enabled
     non_staff_development
+    featured_tags
   ).freeze
 
   UPLOAD_KEYS = %i(

--- a/app/views/admin/settings/edit.html.haml
+++ b/app/views/admin/settings/edit.html.haml
@@ -71,6 +71,8 @@
   - if whitelist_mode?
     .fields-group
       = f.input :non_staff_development, as: :boolean, wrapper: :with_label, label: t('admin.settings.non_staff_development.title'), hint: t('admin.settings.non_staff_development.desc_html')
+    .fields-group
+      = f.input :featured_tags, as: :boolean, wrapper: :with_label, label: t('admin.settings.featured_tags.title'), hint: t('admin.settings.featured_tags.desc_html')
 
   .fields-group
     = f.input :show_staff_badge, as: :boolean, wrapper: :with_label, label: t('admin.settings.show_staff_badge.title'), hint: t('admin.settings.show_staff_badge.desc_html')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -645,6 +645,9 @@ en:
       non_staff_development:
         desc_html: Allow non-staff users to create applications with API access through the UI
         title: Enable the development tab for non-staff
+      featured_tags:
+        desc_html: Allow users to feature hashtags on their profile
+        title: Enable featured hashtags
     site_uploads:
       delete: Delete uploaded file
       destroyed_msg: Site upload successfully deleted!

--- a/config/navigation.rb
+++ b/config/navigation.rb
@@ -6,7 +6,7 @@ SimpleNavigation::Configuration.run do |navigation|
 
     n.item :profile, safe_join([fa_icon('user fw'), t('settings.profile')]), settings_profile_url, if: -> { current_user.functional? } do |s|
       s.item :profile, safe_join([fa_icon('pencil fw'), t('settings.appearance')]), settings_profile_url
-      s.item :featured_tags, safe_join([fa_icon('hashtag fw'), t('settings.featured_tags')]), settings_featured_tags_url
+      s.item :featured_tags, safe_join([fa_icon('hashtag fw'), t('settings.featured_tags')]), settings_featured_tags_url, if: -> { Setting.featured_tags }
       s.item :identity_proofs, safe_join([fa_icon('key fw'), t('settings.identity_proofs')]), settings_identity_proofs_path, highlights_on: %r{/settings/identity_proofs*}, if: proc { current_account.identity_proofs.exists? }
     end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -73,6 +73,7 @@ defaults: &defaults
   require_invite_text: false
   dms_enabled: true
   non_staff_development: true
+  featured_tags: true
 
 development:
   <<: *defaults


### PR DESCRIPTION
- Featured hashtags now configurable by admins in site settings
- featured_tags defaults to true. When set to false, removes the featured hashtags tab from the appearance tab.