### PR TITLE
Add ability to restore deleted posts; custom email notifications for post-level moderation actions

### DIFF
--- a/app/controllers/admin/reported_statuses_controller.rb
+++ b/app/controllers/admin/reported_statuses_controller.rb
@@ -8,6 +8,7 @@ module Admin
       authorize :status, :update?
 
       @form         = Form::StatusBatch.new(form_status_batch_params.merge(current_account: current_account, action: action_from_button))
+      @form.target_account  = @report.target_account
       flash[:alert] = I18n.t('admin.statuses.failed_to_execute') unless @form.save
 
       redirect_to admin_report_path(@report)
@@ -24,7 +25,7 @@ module Admin
     end
 
     def form_status_batch_params
-      params.require(:form_status_batch).permit(status_ids: [])
+      params.require(:form_status_batch).permit(:email_collection => [:text, :send_email_notification], status_ids: [])
     end
 
     def action_from_button
@@ -38,6 +39,8 @@ module Admin
         'disable_replies'
       elsif params[:enable_replies]
         'enable_replies'
+      elsif params[:restore]
+        'restore'
       end
     end
 

--- a/app/controllers/admin/statuses_controller.rb
+++ b/app/controllers/admin/statuses_controller.rb
@@ -35,6 +35,7 @@ module Admin
       authorize :status, :update?
 
       @form         = Form::StatusBatch.new(form_status_batch_params.merge(current_account: current_account, action: action_from_button))
+      @form.target_account  = @account
       flash[:alert] = I18n.t('admin.statuses.failed_to_execute') unless @form.save
 
       redirect_to admin_account_statuses_path(@account.id, current_params)
@@ -47,7 +48,7 @@ module Admin
     private
 
     def form_status_batch_params
-      params.require(:form_status_batch).permit(:action, status_ids: [])
+      params.require(:form_status_batch).permit(:action, :email_text => [:text], status_ids: [])
     end
 
     def set_account

--- a/app/controllers/admin/statuses_controller.rb
+++ b/app/controllers/admin/statuses_controller.rb
@@ -11,7 +11,7 @@ module Admin
     def index
       authorize :status, :index?
 
-      @statuses = @account.statuses.where(visibility: [:public, :unlisted])
+      @statuses = @account.statuses.with_discarded.where(visibility: [:public, :unlisted])
 
       if params[:media]
         account_media_status_ids = @account.media_attachments.attached.reorder(nil).select(:status_id).group(:status_id)
@@ -25,7 +25,7 @@ module Admin
     def show
       authorize :status, :index?
 
-      @statuses = @account.statuses.where(id: params[:id])
+      @statuses = @account.statuses.with_discarded.where(id: params[:id])
       authorize @statuses.first, :show?
 
       @form = Form::StatusBatch.new
@@ -48,7 +48,7 @@ module Admin
     private
 
     def form_status_batch_params
-      params.require(:form_status_batch).permit(:action, :email_text => [:text], status_ids: [])
+      params.require(:form_status_batch).permit(:action, :email_collection => [:text, :send_email_notification], status_ids: [])
     end
 
     def set_account
@@ -75,6 +75,8 @@ module Admin
         'disable_replies'
       elsif params[:enable_replies]
         'enable_replies'
+      elsif params[:restore]
+        'restore'
       end
     end
   end

--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -55,12 +55,6 @@ code {
           text-decoration: none;
         }
       }
-
-      .recommended {
-        position: absolute;
-        margin: 0 4px;
-        margin-top: -2px;
-      }
     }
   }
 
@@ -79,10 +73,6 @@ code {
     .hint {
       margin-bottom: 15px;
     }
-
-    ul {
-      columns: 2;
-    }
   }
 
   .input.with_label {
@@ -99,10 +89,6 @@ code {
     .hint {
       margin-top: 6px;
     }
-
-    ul {
-      flex: 390px;
-    }
   }
 
   .title {
@@ -118,17 +104,6 @@ code {
 
     a {
       color: $highlight-text-color;
-    }
-
-    code {
-      border-radius: 3px;
-      padding: 0.2em 0.4em;
-      background: darken($ui-base-color, 12%);
-    }
-
-    li {
-      list-style: disc;
-      margin-left: 18px;
     }
   }
 
@@ -154,24 +129,6 @@ code {
 
     &::placeholder {
       color: lighten($darker-text-color, 4%);
-    }
-
-    &:invalid {
-      box-shadow: none;
-    }
-
-    &:required:valid {
-      border-color: $valid-value-color;
-    }
-
-    &:hover {
-      border-color: darken($ui-base-color, 20%);
-    }
-
-    &:active,
-    &:focus {
-      border-color: $highlight-text-color;
-      background: darken($ui-base-color, 8%);
     }
   }
 }

--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -16,6 +16,52 @@ code {
   .input {
     margin-bottom: 15px;
     overflow: hidden;
+
+    &.boolean {
+      position: relative;
+      margin-bottom: 0;
+
+      .label_input > label {
+        font-family: inherit;
+        font-size: 14px;
+        padding-top: 5px;
+        color: $primary-text-color;
+        display: block;
+        width: auto;
+      }
+
+      .label_input,
+      .hint {
+        padding-left: 28px;
+      }
+
+      .label_input__wrapper {
+        position: static;
+      }
+
+      label.checkbox {
+        position: absolute;
+        top: 2px;
+        left: 0;
+      }
+
+      label a {
+        color: $highlight-text-color;
+        text-decoration: underline;
+
+        &:hover,
+        &:active,
+        &:focus {
+          text-decoration: none;
+        }
+      }
+
+      .recommended {
+        position: absolute;
+        margin: 0 4px;
+        margin-top: -2px;
+      }
+    }
   }
 
   .input.with_block_label {
@@ -36,6 +82,26 @@ code {
 
     ul {
       columns: 2;
+    }
+  }
+
+  .input.with_label {
+    .label_input > label {
+      font-family: inherit;
+      font-size: 14px;
+      color: $primary-text-color;
+      display: block;
+      margin-bottom: 8px;
+      word-wrap: break-word;
+      font-weight: 500;
+    }
+
+    .hint {
+      margin-top: 6px;
+    }
+
+    ul {
+      flex: 390px;
     }
   }
 

--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -11,6 +11,105 @@ code {
   margin: 0 auto;
 }
 
+.moderation_form {
+
+  .input {
+    margin-bottom: 15px;
+    overflow: hidden;
+  }
+
+  .input.with_block_label {
+    max-width: none;
+
+    & > label {
+      font-family: inherit;
+      font-size: 16px;
+      color: $primary-text-color;
+      display: block;
+      font-weight: 500;
+      padding-top: 5px;
+    }
+
+    .hint {
+      margin-bottom: 15px;
+    }
+
+    ul {
+      columns: 2;
+    }
+  }
+
+  .title {
+    color: #d9e1e8;
+    font-size: 20px;
+    line-height: 28px;
+    font-weight: 400;
+    margin-bottom: 30px;
+  }
+
+  .hint {
+    color: $darker-text-color;
+
+    a {
+      color: $highlight-text-color;
+    }
+
+    code {
+      border-radius: 3px;
+      padding: 0.2em 0.4em;
+      background: darken($ui-base-color, 12%);
+    }
+
+    li {
+      list-style: disc;
+      margin-left: 18px;
+    }
+  }
+
+  span.hint {
+    display: block;
+    font-size: 12px;
+    margin-top: 4px;
+  }
+
+  textarea {
+    box-sizing: border-box;
+    font-size: 16px;
+    color: $primary-text-color;
+    display: block;
+    width: 100%;
+    outline: 0;
+    font-family: inherit;
+    resize: vertical;
+    background: darken($ui-base-color, 10%);
+    border: 1px solid darken($ui-base-color, 14%);
+    border-radius: 4px;
+    padding: 10px;
+
+    &::placeholder {
+      color: lighten($darker-text-color, 4%);
+    }
+
+    &:invalid {
+      box-shadow: none;
+    }
+
+    &:required:valid {
+      border-color: $valid-value-color;
+    }
+
+    &:hover {
+      border-color: darken($ui-base-color, 20%);
+    }
+
+    &:active,
+    &:focus {
+      border-color: $highlight-text-color;
+      background: darken($ui-base-color, 8%);
+    }
+  }
+}
+
 .simple_form {
   &.hidden {
     display: none;

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -164,7 +164,7 @@ class UserMailer < Devise::Mailer
     @resource = user
     @warning  = warning
     @instance = Rails.configuration.x.local_domain
-    @statuses = Status.where(id: status_ids).includes(:account) if status_ids.is_a?(Array)
+    @statuses = Status.with_discarded.where(id: status_ids).includes(:account) if status_ids.is_a?(Array)
 
     I18n.with_locale(@resource.locale || I18n.default_locale) do
       mail to: @resource.email,

--- a/app/models/account_warning.rb
+++ b/app/models/account_warning.rb
@@ -13,7 +13,7 @@
 #
 
 class AccountWarning < ApplicationRecord
-  enum action: %i(none disable sensitive silence suspend), _suffix: :action
+  enum action: %i(none disable sensitive silence suspend delete disable_replies enable_replies nsfw_on nsfw_off), _suffix: :action
 
   belongs_to :account, inverse_of: :account_warnings
   belongs_to :target_account, class_name: 'Account', inverse_of: :targeted_account_warnings

--- a/app/models/account_warning.rb
+++ b/app/models/account_warning.rb
@@ -13,7 +13,7 @@
 #
 
 class AccountWarning < ApplicationRecord
-  enum action: %i(none disable sensitive silence suspend delete disable_replies enable_replies nsfw_on nsfw_off), _suffix: :action
+  enum action: %i(none disable sensitive silence suspend delete disable_replies enable_replies nsfw_on nsfw_off restore), _suffix: :action
 
   belongs_to :account, inverse_of: :account_warnings
   belongs_to :target_account, class_name: 'Account', inverse_of: :targeted_account_warnings

--- a/app/models/admin/action_log.rb
+++ b/app/models/admin/action_log.rb
@@ -31,7 +31,7 @@ class Admin::ActionLog < ApplicationRecord
 
   def set_changes
     case action
-    when :destroy, :create
+    when :destroy, :create, :restore
       self.recorded_changes = target.attributes
     when :update, :promote, :demote
       self.recorded_changes = target.previous_changes

--- a/app/models/admin/action_log_filter.rb
+++ b/app/models/admin/action_log_filter.rb
@@ -35,6 +35,7 @@ class Admin::ActionLogFilter
     reopen_report: { target_type: 'Report', action: 'reopen' }.freeze,
     reset_password_user: { target_type: 'User', action: 'reset_password' }.freeze,
     resolve_report: { target_type: 'Report', action: 'resolve' }.freeze,
+    restore_status: { target_type: 'Status', action: 'restore' }.freeze,
     sensitive_account: { target_type: 'Account', action: 'sensitive' }.freeze,
     silence_account: { target_type: 'Account', action: 'silence' }.freeze,
     suspend_account: { target_type: 'Account', action: 'suspend' }.freeze,

--- a/app/models/form/status_batch.rb
+++ b/app/models/form/status_batch.rb
@@ -3,8 +3,10 @@
 class Form::StatusBatch
   include ActiveModel::Model
   include AccountableConcern
+  include Authorization
 
-  attr_accessor :status_ids, :action, :current_account
+  attr_accessor :status_ids, :action, :current_account, :email_text, :target_account
+  attr_reader :warning
 
   def save
     case action
@@ -28,7 +30,11 @@ class Form::StatusBatch
         log_action :update, status
       end
     end
-
+    
+    if email_text[:text] != ''
+      process_warning!
+      process_email!
+    end
     true
   rescue ActiveRecord::RecordInvalid
     false
@@ -37,11 +43,14 @@ class Form::StatusBatch
   def delete_statuses
     Status.where(id: status_ids).reorder(nil).find_each do |status|
       status.discard
-      RemovalWorker.perform_async(status.id, immediate: true)
       Tombstone.find_or_create_by(uri: status.uri, account: status.account, by_moderator: true)
       log_action :destroy, status
     end
-
+    
+    if email_text[:text] != ''
+      process_warning!
+      process_email!
+    end
     true
   end
 
@@ -58,8 +67,30 @@ class Form::StatusBatch
       end
     end
     
+    if email_text[:text] != ''
+      process_warning!
+      process_email!
+    end
     true
   rescue ActiveRecord::RecordInvalid
     false
+  end
+
+  def process_warning!
+    authorize(target_account, :warn?)
+
+    @warning = AccountWarning.create!(target_account: target_account,
+                                      account: current_account,
+                                      action: action,
+                                      text: email_text[:text])
+
+    # A log entry is only interesting if the warning contains
+    # custom text from someone. Otherwise it's just noise.
+
+    log_action(:create, warning) if warning.text.present?
+  end
+
+  def process_email!
+    UserMailer.warning(target_account.user, warning, status_ids).deliver_later!
   end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -71,7 +71,6 @@ class Report < ApplicationRecord
       target_account.update(trust_level: Account::TRUST_LEVELS[:trusted])
     end
 
-    RemovalWorker.push_bulk(Status.with_discarded.discarded.where(id: status_ids).pluck(:id)) { |status_id| [status_id, { immediate: true }] }
     update!(action_taken: true, action_taken_by_account_id: acting_account.id)
   end
 

--- a/app/views/admin/reports/show.html.haml
+++ b/app/views/admin/reports/show.html.haml
@@ -105,9 +105,13 @@
   %hr.spacer/
 
   = form_for(@form, url: admin_report_reported_statuses_path(@report.id), html: { class: 'moderation_form' }) do |f|
-    = f.simple_fields_for :email_text do |email_form|
+    = f.simple_fields_for :email_collection do |email_form|
       .fields-group
-        = email_form.input :text, as: :text, wrapper: :with_block_label, label: t('admin.statuses.email_form.title'), hint: t('admin.reports.email_form.desc_html'), required: false
+        = email_form.input :send_email_notification, as: :boolean, wrapper: :with_label, :input_html => { :checked => true }, label: t('admin.statuses.email_form.send_email_notification.title'), hint: t('admin.reports.email_form.send_email_notification.desc_html')
+      
+      %br/
+      .fields-group
+        = email_form.input :text, as: :text, wrapper: :with_block_label, label: t('admin.statuses.email_form.text.title'), hint: t('admin.statuses.email_form.text.desc_html'), required: false
 
     %hr.spacer/
 
@@ -122,6 +126,7 @@
             = f.button safe_join([fa_icon('comments-o'), t('admin.statuses.batch.disable_replies')]), name: :disable_replies, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
             = f.button safe_join([fa_icon('comments'), t('admin.statuses.batch.enable_replies')]), name: :enable_replies, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
           = f.button safe_join([fa_icon('trash'), t('admin.statuses.batch.delete')]), name: :delete, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
+          = f.button safe_join([fa_icon('recycle'), t('admin.statuses.batch.restore')]), name: :restore, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
       .batch-table__body
         = render partial: 'admin/reports/status', collection: @report.statuses, locals: { f: f }
 

--- a/app/views/admin/reports/show.html.haml
+++ b/app/views/admin/reports/show.html.haml
@@ -104,7 +104,13 @@
 - unless @report.statuses.empty?
   %hr.spacer/
 
-  = form_for(@form, url: admin_report_reported_statuses_path(@report.id)) do |f|
+  = form_for(@form, url: admin_report_reported_statuses_path(@report.id), html: { class: 'moderation_form' }) do |f|
+    = f.simple_fields_for :email_text do |email_form|
+      .fields-group
+        = email_form.input :text, as: :text, wrapper: :with_block_label, label: t('admin.statuses.email_form.title'), hint: t('admin.reports.email_form.desc_html'), required: false
+
+    %hr.spacer/
+
     .batch-table
       .batch-table__toolbar
         %label.batch-table__toolbar__select.batch-checkbox-all

--- a/app/views/admin/statuses/index.html.haml
+++ b/app/views/admin/statuses/index.html.haml
@@ -23,9 +23,13 @@
   = hidden_field_tag :page, params[:page]
   = hidden_field_tag :media, params[:media]
 
-  = f.simple_fields_for :email_text do |email_form|
+  = f.simple_fields_for :email_collection do |email_form|
     .fields-group
-      = email_form.input :text, as: :text, wrapper: :with_block_label, label: t('admin.statuses.email_form.title'), hint: t('admin.statuses.email_form.desc_html'), required: false
+      = email_form.input :send_email_notification, as: :boolean, wrapper: :with_label, :input_html => { :checked => true }, label: t('admin.statuses.email_form.send_email_notification.title'), hint: t('admin.statuses.email_form.send_email_notification.desc_html')
+    
+    %br/
+    .fields-group
+      = email_form.input :text, as: :text, wrapper: :with_block_label, label: t('admin.statuses.email_form.text.title'), hint: t('admin.statuses.email_form.text.desc_html'), required: false
 
   %hr.spacer/
 
@@ -40,6 +44,7 @@
           = f.button safe_join([fa_icon('comments-o'), t('admin.statuses.batch.disable_replies')]), name: :disable_replies, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
           = f.button safe_join([fa_icon('comments'), t('admin.statuses.batch.enable_replies')]), name: :enable_replies, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
         = f.button safe_join([fa_icon('trash'), t('admin.statuses.batch.delete')]), name: :delete, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
+        = f.button safe_join([fa_icon('recycle'), t('admin.statuses.batch.restore')]), name: :restore, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
     .batch-table__body
       = render partial: 'admin/reports/status', collection: @statuses, locals: { f: f }
 

--- a/app/views/admin/statuses/index.html.haml
+++ b/app/views/admin/statuses/index.html.haml
@@ -19,9 +19,15 @@
 
 %hr.spacer/
 
-= form_for(@form, url: admin_account_statuses_path(@account.id)) do |f|
+= form_for(@form, url: admin_account_statuses_path(@account.id), html: { class: 'moderation_form' }) do |f|
   = hidden_field_tag :page, params[:page]
   = hidden_field_tag :media, params[:media]
+
+  = f.simple_fields_for :email_text do |email_form|
+    .fields-group
+      = email_form.input :text, as: :text, wrapper: :with_block_label, label: t('admin.statuses.email_form.title'), hint: t('admin.statuses.email_form.desc_html'), required: false
+
+  %hr.spacer/
 
   .batch-table
     .batch-table__toolbar

--- a/app/views/admin/statuses/show.html.haml
+++ b/app/views/admin/statuses/show.html.haml
@@ -11,9 +11,15 @@
 
 %hr.spacer/
 
-= form_for(@form, url: admin_account_statuses_path(@account.id)) do |f|
+= form_for(@form, url: admin_account_statuses_path(@account.id), html: { class: 'moderation_form' }) do |f|
   = hidden_field_tag :page, params[:page]
   = hidden_field_tag :media, params[:media]
+
+  = f.simple_fields_for :email_text do |email_form|
+    .fields-group
+      = email_form.input :text, as: :text, wrapper: :with_block_label, label: t('admin.statuses.email_form.title'), hint: t('admin.statuses.email_form.desc_html'), required: false
+
+  %hr.spacer/
 
   .batch-table
     .batch-table__toolbar

--- a/app/views/admin/statuses/show.html.haml
+++ b/app/views/admin/statuses/show.html.haml
@@ -15,9 +15,13 @@
   = hidden_field_tag :page, params[:page]
   = hidden_field_tag :media, params[:media]
 
-  = f.simple_fields_for :email_text do |email_form|
+  = f.simple_fields_for :email_collection do |email_form|
     .fields-group
-      = email_form.input :text, as: :text, wrapper: :with_block_label, label: t('admin.statuses.email_form.title'), hint: t('admin.statuses.email_form.desc_html'), required: false
+      = email_form.input :send_email_notification, as: :boolean, wrapper: :with_label, :input_html => { :checked => true }, label: t('admin.statuses.email_form.send_email_notification.title'), hint: t('admin.statuses.email_form.send_email_notification.desc_html')
+    
+    %br/
+    .fields-group
+      = email_form.input :text, as: :text, wrapper: :with_block_label, label: t('admin.statuses.email_form.text.title'), hint: t('admin.statuses.email_form.text.desc_html'), required: false
 
   %hr.spacer/
 
@@ -32,5 +36,6 @@
           = f.button safe_join([fa_icon('comments-o'), t('admin.statuses.batch.disable_replies')]), name: :disable_replies, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
           = f.button safe_join([fa_icon('comments'), t('admin.statuses.batch.enable_replies')]), name: :enable_replies, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
         = f.button safe_join([fa_icon('trash'), t('admin.statuses.batch.delete')]), name: :delete, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
+        = f.button safe_join([fa_icon('recycle'), t('admin.statuses.batch.restore')]), name: :restore, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
     .batch-table__body
       = render partial: 'admin/reports/status', collection: @statuses, locals: { f: f }

--- a/app/workers/scheduler/status_cleanup_scheduler.rb
+++ b/app/workers/scheduler/status_cleanup_scheduler.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class Scheduler::StatusCleanupScheduler
+    include Sidekiq::Worker
+  
+    sidekiq_options lock: :until_executed, retry: 0
+  
+    def perform
+      clean_discarded_statuses!
+    end
+  
+    private
+  
+    def clean_discarded_statuses!
+      RemovalWorker.push_bulk(Status.with_discarded.discarded.where('deleted_at <= ?', 14.days.ago).pluck(:id)) { |status_id| [status_id, { immediate: true }] }
+    end
+  end
+  

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -523,6 +523,8 @@ en:
       comment:
         none: None
       created_at: Reported
+      email_form:
+        desc_html: Optional. Send an email that explains why you are taking moderation action on the post(s). When you click an action, text in the box will be sent to the affected user. If the box is empty, no email will be sent. This is NOT for account-level actions like "Freeze." This IS for post-level actions like "Delete."
       forwarded: Forwarded
       forwarded_to: Forwarded to %{domain}
       mark_as_resolved: Mark as resolved
@@ -684,6 +686,9 @@ en:
         nsfw_off: Mark as not sensitive
         nsfw_on: Mark as sensitive
       deleted: Deleted
+      email_form:
+        desc_html: Optional. Send an email that explains why you are taking moderation action. When you click an action, text in the box will be sent to the affected user. If the box is empty, no email will be sent.
+        title: Explanation email
       failed_to_execute: Failed to execute
       media:
         title: Media
@@ -1412,6 +1417,11 @@ en:
         sensitive: Your uploaded media files and linked media will be treated as sensitive.
         silence: You can still use your account but only people who are already following you will see your posts on this server, and you may be excluded from various public listings. However, others may still manually follow you.
         suspend: You can no longer use your account, and your profile and other data are no longer accessible. You can still login to request a backup of your data until the data is fully removed, but we will retain some data to prevent you from evading the suspension.
+        delete: Your post has been deleted.
+        nsfw_on: Your post has been marked as sensitive. Media will be hidden behind a content warning.
+        nsfw_off: Your post has been marked as not sensitive. Media will no longer be hidden behind a content warning.
+        disable_replies: Replies have been turned off for your post. No one will be able to reply to your original post or any existing replies.
+        enable_replies: Replies have been turned on for your post. People will be able to reply to your original post and any existing replies.
       get_in_touch: You can reply to this e-mail to get in touch with the staff of %{instance}.
       review_server_policies: Review server policies
       statuses: 'Specifically, for:'
@@ -1421,12 +1431,22 @@ en:
         sensitive: Your account %{acct} posting media has been marked as sensitive
         silence: Your account %{acct} has been limited
         suspend: Your account %{acct} has been suspended
+        delete: Your post has been deleted
+        nsfw_on: Your post has been marked as sensitive
+        nsfw_off: Your post has been marked as not sensitive
+        disable_replies: Replies have been turned off for your post
+        enable_replies: Replies have been turned on for your post
       title:
         disable: Account frozen
         none: Warning
         sensitive: Your media has been marked as sensitive
         silence: Account limited
         suspend: Account suspended
+        delete: Post deleted
+        nsfw_on: Post marked sensitive
+        nsfw_off: Post marked not sensitive
+        disable_replies: Replies disabled for your post
+        enable_replies: Replies enabled for your post
     welcome:
       edit_profile_action: Setup profile
       edit_profile_step: You can customize your profile by uploading an avatar, header, changing your display name and more. If you’d like to review new followers before they’re allowed to follow you, you can lock your account.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -248,6 +248,7 @@ en:
         reopen_report: Reopen Report
         reset_password_user: Reset Password
         resolve_report: Resolve Report
+        restore_status: Restore Status
         sensitive_account: Mark the media in your account as sensitive
         silence_account: Silence Account
         suspend_account: Suspend Account
@@ -289,6 +290,7 @@ en:
         reopen_report: "%{name} reopened report %{target}"
         reset_password_user: "%{name} reset password of user %{target}"
         resolve_report: "%{name} resolved report %{target}"
+        restore_status: "%{name} restored status by %{target}"
         sensitive_account: "%{name} marked %{target}'s media as sensitive"
         silence_account: "%{name} silenced %{target}'s account"
         suspend_account: "%{name} suspended %{target}'s account"
@@ -524,8 +526,8 @@ en:
         none: None
       created_at: Reported
       email_form:
-        desc_html: Optional. Send an email that explains why you are taking moderation action on the post(s). When you click an action, text in the box will be sent to the affected user. If the box is empty, no email will be sent. This is NOT for account-level actions like "Freeze." This IS for post-level actions like "Delete."
-      forwarded: Forwarded
+        send_email_notification:
+          desc_html: The user will receive an explanation of what happened with their post(s). This is NOT for account-level actions like "Freeze." This IS for post-level actions like "Delete."
       forwarded_to: Forwarded to %{domain}
       mark_as_resolved: Mark as resolved
       mark_as_unresolved: Mark as unresolved
@@ -683,12 +685,17 @@ en:
         delete: Delete
         disable_replies: Disable replies
         enable_replies: Enable replies
-        nsfw_off: Mark as not sensitive
-        nsfw_on: Mark as sensitive
+        nsfw_off: Mark not sensitive
+        nsfw_on: Mark sensitive
+        restore: Restore
       deleted: Deleted
       email_form:
-        desc_html: Optional. Send an email that explains why you are taking moderation action. When you click an action, text in the box will be sent to the affected user. If the box is empty, no email will be sent.
-        title: Explanation email
+        send_email_notification:
+          desc_html: The user will receive an explanation of what happened with their post(s)
+          title: Notify the user by email
+        text:
+          desc_html: Optional. If you are notifying the user by email, you can provide a custom explanation.
+          title: Custom explanation
       failed_to_execute: Failed to execute
       media:
         title: Media
@@ -1413,40 +1420,43 @@ en:
       title: Sign in attempt
     warning:
       explanation:
+        delete: Your post has been deleted.
         disable: You can no longer login to your account or use it in any other way, but your profile and other data remains intact.
+        disable_replies: Replies have been turned off for your post. No one will be able to reply to your original post or any existing replies.
+        enable_replies: Replies have been turned on for your post. People will be able to reply to your original post and any existing replies.
+        nsfw_off: Your post has been marked as not sensitive. Media will no longer be hidden behind a content warning.
+        nsfw_on: Your post has been marked as sensitive. Media will be hidden behind a content warning.
+        restore: Your post has been restored.
         sensitive: Your uploaded media files and linked media will be treated as sensitive.
         silence: You can still use your account but only people who are already following you will see your posts on this server, and you may be excluded from various public listings. However, others may still manually follow you.
         suspend: You can no longer use your account, and your profile and other data are no longer accessible. You can still login to request a backup of your data until the data is fully removed, but we will retain some data to prevent you from evading the suspension.
-        delete: Your post has been deleted.
-        nsfw_on: Your post has been marked as sensitive. Media will be hidden behind a content warning.
-        nsfw_off: Your post has been marked as not sensitive. Media will no longer be hidden behind a content warning.
-        disable_replies: Replies have been turned off for your post. No one will be able to reply to your original post or any existing replies.
-        enable_replies: Replies have been turned on for your post. People will be able to reply to your original post and any existing replies.
       get_in_touch: You can reply to this e-mail to get in touch with the staff of %{instance}.
       review_server_policies: Review server policies
       statuses: 'Specifically, for:'
       subject:
+        delete: Your post has been deleted
         disable: Your account %{acct} has been frozen
+        disable_replies: Replies have been turned off for your post
+        enable_replies: Replies have been turned on for your post
         none: Warning for %{acct}
+        nsfw_off: Your post has been marked as not sensitive
+        nsfw_on: Your post has been marked as sensitive
+        restore: Your post has been restored
         sensitive: Your account %{acct} posting media has been marked as sensitive
         silence: Your account %{acct} has been limited
         suspend: Your account %{acct} has been suspended
-        delete: Your post has been deleted
-        nsfw_on: Your post has been marked as sensitive
-        nsfw_off: Your post has been marked as not sensitive
-        disable_replies: Replies have been turned off for your post
-        enable_replies: Replies have been turned on for your post
       title:
+        delete: Post deleted
         disable: Account frozen
+        disable_replies: Replies disabled for your post
+        enable_replies: Replies enabled for your post
         none: Warning
+        nsfw_off: Post marked not sensitive
+        nsfw_on: Post marked sensitive
+        restore: Post restored
         sensitive: Your media has been marked as sensitive
         silence: Account limited
         suspend: Account suspended
-        delete: Post deleted
-        nsfw_on: Post marked sensitive
-        nsfw_off: Post marked not sensitive
-        disable_replies: Replies disabled for your post
-        enable_replies: Replies enabled for your post
     welcome:
       edit_profile_action: Setup profile
       edit_profile_step: You can customize your profile by uploading an avatar, header, changing your display name and more. If you’d like to review new followers before they’re allowed to follow you, you can lock your account.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -528,6 +528,7 @@ en:
       email_form:
         send_email_notification:
           desc_html: The user will receive an explanation of what happened with their post(s). This is NOT for account-level actions like "Freeze." This IS for post-level actions like "Delete."
+      forwarded: Forwarded
       forwarded_to: Forwarded to %{domain}
       mark_as_resolved: Mark as resolved
       mark_as_unresolved: Mark as unresolved

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -33,6 +33,10 @@
     cron: '<%= Random.rand(0..59) %> <%= Random.rand(4..6) %> * * *'
     class: Scheduler::UserCleanupScheduler
     queue: scheduler
+  status_cleanup_scheduler:
+    cron: '<%= Random.rand(0..59) %> <%= Random.rand(4..6) %> * * *'
+    class: Scheduler::StatusCleanupScheduler
+    queue: scheduler
   ip_cleanup_scheduler:
     cron: '<%= Random.rand(0..59) %> <%= Random.rand(3..5) %> * * *'
     class: Scheduler::IpCleanupScheduler

--- a/spec/workers/scheduler/status_cleanup_scheduler_spec.rb
+++ b/spec/workers/scheduler/status_cleanup_scheduler_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+describe Scheduler::StatusCleanupScheduler do
+  subject { described_class.new }
+  
+  let!(:alice)  { Fabricate(:account, user: Fabricate(:user)) }
+  let!(:old_status) { Fabricate(:status, account: alice, deleted_at: 15.days.ago)}
+  let!(:new_status) { Fabricate(:status, account: alice, deleted_at: 1.hour.ago) }
+
+
+  it 'removes old deleted statuses' do
+    subject.perform
+
+    expect(Status.find_by(id: old_status.id)).to be_nil
+    expect(Status.with_discarded.find_by(id: old_status.id)).to be_nil
+
+    expect(Status.find_by(id: new_status.id)).to be_nil
+    expect(Status.with_discarded.find_by(id: new_status.id)).to_not be_nil
+  end
+end


### PR DESCRIPTION
- Staff can now send a custom email notification for post-level moderation actions
- Deleted posts can be restored: All posts that are deleted are kept in a "soft-delete" for 14 days after which they are permanently deleted. Staff can restore posts during that period.