### PR TITLE
Openid email verified fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ end
 gem 'net-ldap', '~> 0.16'
 gem 'omniauth-cas', '~> 2.0'
 gem 'omniauth-saml', '~> 1.10'
-gem 'gitlab-omniauth-openid-connect', '~>0.4.0', require: 'omniauth_openid_connect'
+gem 'gitlab-omniauth-openid-connect', '~>0.5.0', require: 'omniauth_openid_connect'
 gem 'omniauth', '~> 1.9'
 gem 'omniauth-rails_csrf_protection', '~> 0.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -240,7 +240,7 @@ GEM
     fuubar (2.5.0)
       rspec-core (~> 3.0)
       ruby-progressbar (~> 1.4)
-    gitlab-omniauth-openid-connect (0.4.0)
+    gitlab-omniauth-openid-connect (0.5.0)
       addressable (~> 2.7)
       omniauth (~> 1.9)
       openid_connect (~> 1.2)
@@ -758,7 +758,7 @@ DEPENDENCIES
   fog-core (<= 2.1.0)
   fog-openstack (~> 0.3)
   fuubar (~> 2.5)
-  gitlab-omniauth-openid-connect (~> 0.4.0)
+  gitlab-omniauth-openid-connect (~> 0.5.0)
   hamlit-rails (~> 0.2)
   health_check!
   hiredis (~> 0.6)

--- a/app/models/concerns/omniauthable.rb
+++ b/app/models/concerns/omniauthable.rb
@@ -47,9 +47,8 @@ module Omniauthable
 
       strategy          = Devise.omniauth_configs[auth.provider.to_sym].strategy
       assume_verified   = strategy&.security&.assume_email_is_verified
-      email_is_verified = auth.info.verified || auth.info.verified_email || assume_verified
+      email_is_verified = auth.info.verified || auth.info.verified_email || auth.info.email_verified || assume_verified
       email             = auth.info.verified_email || auth.info.email
-      email             = nil unless email_is_verified
 
       user = User.find_by(email: email) if email_is_verified
 
@@ -58,7 +57,7 @@ module Omniauthable
       user = User.new(user_params_from_auth(email, auth))
 
       user.account.avatar_remote_url = auth.info.image if auth.info.image =~ /\A#{URI::DEFAULT_PARSER.make_regexp(%w(http https))}\z/
-      user.skip_confirmation!
+      user.skip_confirmation! if email_is_verified
       user.save!
       user
     end

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -98,7 +98,7 @@ Devise.setup do |config|
     oidc_options[:client_options][:jwks_uri] = ENV['OIDC_JWKS_URI'] if ENV['OIDC_JWKS_URI'] #NEED when discovery != true
     oidc_options[:client_options][:end_session_endpoint] = ENV['OIDC_END_SESSION_ENDPOINT'] if ENV['OIDC_END_SESSION_ENDPOINT'] #OPTIONAL
     oidc_options[:security] = {}
-    oidc_options[:security][:assume_email_is_verified] = true
+    oidc_options[:security][:assume_email_is_verified] = ENV['OIDC_SECURITY_ASSUME_EMAIL_IS_VERIFIED'] == 'true'
     config.omniauth :openid_connect, oidc_options
   end
 end


### PR DESCRIPTION
- Properly check and handle email verification for OpenID Connect
- Allow SSO users to confirm their email. Previous functionality gave SSO users a temp email if the SSO provider didn't indicate the email was verified. This was confusing.