### PR TITLE
Refactor configurable direct messages so it works in all federation modes

### DIFF
--- a/app/controllers/admin/domain_allows_controller.rb
+++ b/app/controllers/admin/domain_allows_controller.rb
@@ -13,12 +13,8 @@ class Admin::DomainAllowsController < Admin::BaseController
     authorize :domain_allow, :create?
 
     @domain_allow = DomainAllow.new(resource_params)
-    was_siloed = completely_siloed?
     if @domain_allow.save
       log_action :create, @domain_allow
-      if was_siloed
-        Setting.dms_enabled = true
-      end
       redirect_to admin_instances_path, notice: I18n.t('admin.domain_allows.created_msg')
     else
       render :new

--- a/app/controllers/api/v1/statuses_controller.rb
+++ b/app/controllers/api/v1/statuses_controller.rb
@@ -87,10 +87,8 @@ class Api::V1::StatusesController < Api::BaseController
       if params[:visibility] == 'unlisted'
         not_found
       end
-      if completely_siloed?
-        if !Setting.dms_enabled && params[:visibility] == 'direct'
-          not_found
-        end
+      if params[:visibility] == 'direct'  && !Setting.dms_enabled
+        not_found
       end
     end
   end

--- a/app/controllers/api/v1/statuses_controller.rb
+++ b/app/controllers/api/v1/statuses_controller.rb
@@ -8,7 +8,7 @@ class Api::V1::StatusesController < Api::BaseController
   before_action :require_user!, except:  [:show, :context]
   before_action :set_status, only:       [:show, :context]
   before_action :set_thread, only:       [:create]
-  # before_action :check_visibility!, only: [:create]
+  before_action :check_visibility!, only: [:create]
 
   override_rate_limit_headers :create, family: :statuses
 

--- a/app/controllers/api/v1/statuses_controller.rb
+++ b/app/controllers/api/v1/statuses_controller.rb
@@ -8,7 +8,7 @@ class Api::V1::StatusesController < Api::BaseController
   before_action :require_user!, except:  [:show, :context]
   before_action :set_status, only:       [:show, :context]
   before_action :set_thread, only:       [:create]
-  before_action :check_visibility!, only: [:create]
+  # before_action :check_visibility!, only: [:create]
 
   override_rate_limit_headers :create, family: :statuses
 

--- a/app/javascript/mastodon/components/status_action_bar.js
+++ b/app/javascript/mastodon/components/status_action_bar.js
@@ -323,7 +323,7 @@ class StatusActionBar extends ImmutablePureComponent {
 
     return (
       <div className='status__action-bar'>
-        <IconButton className='status__action-bar-button' disabled={status.get('replies_disabled')} title={replyTitle} icon={status.get('in_reply_to_account_id') === status.getIn(['account', 'id']) ? 'reply' : replyIcon} onClick={this.handleReplyClick} counter={status.get('replies_count')} obfuscateCount />
+        <IconButton className='status__action-bar-button' disabled={status.get('replies_disabled') || (!dmsEnabled && status.get('visibility') === 'direct')} title={replyTitle} icon={status.get('in_reply_to_account_id') === status.getIn(['account', 'id']) ? 'reply' : replyIcon} onClick={this.handleReplyClick} counter={status.get('replies_count')} obfuscateCount />
         <IconButton className={classNames('status__action-bar-button', { reblogPrivate })} disabled={!publicStatus && !reblogPrivate}  active={status.get('reblogged')} pressed={status.get('reblogged')} title={reblogTitle} icon='retweet' onClick={this.handleReblogClick} />
         <IconButton className='status__action-bar-button star-icon' animate active={status.get('favourited')} pressed={status.get('favourited')} title={intl.formatMessage(messages.favourite)} icon='star' onClick={this.handleFavouriteClick} />
 

--- a/app/javascript/mastodon/features/status/components/action_bar.js
+++ b/app/javascript/mastodon/features/status/components/action_bar.js
@@ -274,7 +274,7 @@ class ActionBar extends React.PureComponent {
 
     return (
       <div className='detailed-status__action-bar'>
-        <div className='detailed-status__button'><IconButton title={intl.formatMessage(messages.reply)} disabled={status.get('replies_disabled')} icon={status.get('in_reply_to_account_id') === status.getIn(['account', 'id']) ? 'reply' : replyIcon} onClick={this.handleReplyClick} /></div>
+        <div className='detailed-status__button'><IconButton title={intl.formatMessage(messages.reply)} disabled={status.get('replies_disabled') || (!dmsEnabled && status.get('visibility') === 'direct')} icon={status.get('in_reply_to_account_id') === status.getIn(['account', 'id']) ? 'reply' : replyIcon} onClick={this.handleReplyClick} /></div>
         <div className='detailed-status__button' ><IconButton className={classNames({ reblogPrivate })} disabled={!publicStatus && !reblogPrivate} active={status.get('reblogged')} title={reblogTitle} icon='retweet' onClick={this.handleReblogClick} /></div>
         <div className='detailed-status__button'><IconButton className='star-icon' animate active={status.get('favourited')} title={intl.formatMessage(messages.favourite)} icon='star' onClick={this.handleFavouriteClick} /></div>
         {shareButton}

--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -232,7 +232,7 @@ class FeedManager
     aggregate    = account.user&.aggregates_reblogs?
     timeline_key = key(:home, account.id)
 
-    account.statuses.limit(limit).each do |status|
+    account.statuses.where.not(visibility: :direct).limit(limit).each do |status|
       add_to_feed(:home, account.id, status, aggregate)
     end
 

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -156,6 +156,10 @@ class Account < ApplicationRecord
     %w(Application Service).include? actor_type
   end
 
+  def dms_enabled?
+    Setting.dms_enabled
+  end
+
   def instance_actor?
     id == -99
   end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -327,17 +327,15 @@ class Status < ApplicationRecord
         where(visibility: visibility)
       elsif target_account.blocking?(account) || (account.domain.present? && target_account.domain_blocking?(account.domain)) # get rid of blocked peeps
         none
-      elsif account.id == target_account.id # author can see own stuff
-        all
       else
         # followers can see followers-only stuff, but also things they are mentioned in.
         # non-followers can see everything that isn't private/direct, but can see stuff they are mentioned in.
-        visibility.push(:private) if account.following?(target_account)
+        visibility.push(:private) if account.following?(target_account) || account.id == target_account.id
 
         scope = left_outer_joins(:reblog)
 
         scope.where(visibility: visibility)
-             .or(scope.where(id: account.mentions.select(:status_id)))
+             .or(scope.where(id: account.mentions.select(:status_id)).where.not(visibility: :direct))
              .merge(scope.where(reblog_of_id: nil).or(scope.where.not(reblogs_statuses: { account_id: account.excluded_from_timeline_account_ids })))
       end
     end

--- a/app/serializers/rest/account_serializer.rb
+++ b/app/serializers/rest/account_serializer.rb
@@ -5,7 +5,7 @@ class REST::AccountSerializer < ActiveModel::Serializer
 
   attributes :id, :username, :acct, :display_name, :locked, :bot, :discoverable, :group, :created_at,
              :note, :url, :avatar, :avatar_static, :header, :header_static,
-             :followers_count, :following_count, :statuses_count, :last_status_at, :user_staff, :user_admin, :user_moderator
+             :followers_count, :following_count, :statuses_count, :last_status_at, :user_staff, :user_admin, :user_moderator, :dms_enabled
 
   has_one :moved_to_account, key: :moved, serializer: REST::AccountSerializer, if: :moved_and_not_nested?
 
@@ -111,5 +111,9 @@ class REST::AccountSerializer < ActiveModel::Serializer
 
   def user_moderator
     object.user_moderator?
+  end
+
+  def dms_enabled
+    object.dms_enabled?
   end
 end

--- a/app/services/fan_out_on_write_service.rb
+++ b/app/services/fan_out_on_write_service.rb
@@ -6,14 +6,13 @@ class FanOutOnWriteService < BaseService
   def call(status)
     raise Mastodon::RaceConditionError if status.visibility.nil?
 
-    deliver_to_self(status) if status.account.local?
-
     if status.direct_visibility?
       deliver_to_mentioned_followers(status)
       deliver_to_own_conversation(status)
     elsif status.limited_visibility?
       deliver_to_mentioned_followers(status)
     else
+      deliver_to_self(status) if status.account.local?
       deliver_to_followers(status)
       deliver_to_lists(status)
     end

--- a/app/services/notify_service.rb
+++ b/app/services/notify_service.rb
@@ -109,6 +109,7 @@ class NotifyService < BaseService
     blocked ||= optional_non_following_and_direct?               # Options
     blocked ||= conversation_muted?
     blocked ||= send("blocked_#{@notification.type}?")           # Type-dependent filters
+    blocked ||= direct_message? && !Setting.dms_enabled
     blocked
   end
 

--- a/app/services/process_mentions_service.rb
+++ b/app/services/process_mentions_service.rb
@@ -50,7 +50,7 @@ class ProcessMentionsService < BaseService
   private
 
   def mention_undeliverable?(mentioned_account)
-    mentioned_account.nil? || (!mentioned_account.local? && mentioned_account.ostatus?) || (@status.visibility == "direct" && !mentioned_account.dms_enabled?)
+    mentioned_account.nil? || (!mentioned_account.local? && mentioned_account.ostatus?)
   end
 
   def create_notification(mention)

--- a/app/services/process_mentions_service.rb
+++ b/app/services/process_mentions_service.rb
@@ -50,7 +50,7 @@ class ProcessMentionsService < BaseService
   private
 
   def mention_undeliverable?(mentioned_account)
-    mentioned_account.nil? || (!mentioned_account.local? && mentioned_account.ostatus?)
+    mentioned_account.nil? || (!mentioned_account.local? && mentioned_account.ostatus?) || (@status.visibility == "direct" && !mentioned_account.dms_enabled?)
   end
 
   def create_notification(mention)

--- a/app/views/admin/settings/edit.html.haml
+++ b/app/views/admin/settings/edit.html.haml
@@ -79,10 +79,6 @@
 
     .fields-group
       = f.input :show_known_fediverse_at_about_page, as: :boolean, wrapper: :with_label, label: t('admin.settings.show_known_fediverse_at_about_page.title'), hint: t('admin.settings.show_known_fediverse_at_about_page.desc_html')
-  
-  - if completely_siloed?
-    .fields-group
-      = f.input :dms_enabled, as: :boolean, wrapper: :with_label, label: t('admin.settings.dms_enabled.title'), hint: t('admin.settings.dms_enabled.desc_html')
 
   - if whitelist_mode?
     .fields-group
@@ -91,6 +87,8 @@
       = f.input :featured_tags, as: :boolean, wrapper: :with_label, label: t('admin.settings.featured_tags.title'), hint: t('admin.settings.featured_tags.desc_html')
     .fields-group
       = f.input :disable_replies, as: :boolean, wrapper: :with_label, label: t('admin.settings.disable_replies.title'), hint: t('admin.settings.disable_replies.desc_html')
+    .fields-group
+      = f.input :dms_enabled, as: :boolean, wrapper: :with_label, label: t('admin.settings.dms_enabled.title'), hint: t('admin.settings.dms_enabled.desc_html')
 
 
   .fields-group

--- a/app/views/admin/settings/edit.html.haml
+++ b/app/views/admin/settings/edit.html.haml
@@ -87,9 +87,9 @@
       = f.input :featured_tags, as: :boolean, wrapper: :with_label, label: t('admin.settings.featured_tags.title'), hint: t('admin.settings.featured_tags.desc_html')
     .fields-group
       = f.input :disable_replies, as: :boolean, wrapper: :with_label, label: t('admin.settings.disable_replies.title'), hint: t('admin.settings.disable_replies.desc_html')
-    .fields-group
-      = f.input :dms_enabled, as: :boolean, wrapper: :with_label, label: t('admin.settings.dms_enabled.title'), hint: t('admin.settings.dms_enabled.desc_html')
 
+  .fields-group
+    = f.input :dms_enabled, as: :boolean, wrapper: :with_label, label: t('admin.settings.dms_enabled.title'), hint: t('admin.settings.dms_enabled.desc_html')
 
   .fields-group
     = f.input :show_staff_badge, as: :boolean, wrapper: :with_label, label: t('admin.settings.show_staff_badge.title'), hint: t('admin.settings.show_staff_badge.desc_html')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -610,7 +610,7 @@ en:
         desc_html: Enable moderators to disable replies on a thread. Effective only if the servers you federate with are compliant. Thus it's only recommended if your server is in limited federation mode.
         title: Allow moderators to disable replies
       dms_enabled:
-        desc_html: Allow users to exchange direct messages. Turning off direct messages is effective only if the servers you federate with are compliant. Thus turning off direct messages is only recommended if your server is in limited federation mode.
+        desc_html: Allow users to exchange direct messages.
         title: Enable direct messages
       domain_blocks:
         all: To everyone

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -607,10 +607,10 @@ en:
         desc_html: Affects all users who have not changed this setting themselves
         title: Opt users out of search engine indexing by default
       disable_replies:
-        desc_html: Effective only if the servers you federate with are compliant. Thus it's only recommended if your server is in limited federation mode.
+        desc_html: Enable moderators to disable replies on a thread. Effective only if the servers you federate with are compliant. Thus it's only recommended if your server is in limited federation mode.
         title: Allow moderators to disable replies
       dms_enabled:
-        desc_html: Allow users to send direct messages
+        desc_html: Allow users to exchange direct messages. Turning off direct messages is effective only if the servers you federate with are compliant. Thus turning off direct messages is only recommended if your server is in limited federation mode.
         title: Enable direct messages
       domain_blocks:
         all: To everyone


### PR DESCRIPTION
- Refactor configurable direct messages so it works in all federation modes
- Removes DMs from all timelines and profiles — only place DMs now appear is in the dedicated DMs tab