### PR TITLE
staff can see follower-only posts; made locked posts/accounts configurable by admins

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -15,6 +15,7 @@ module Admin
 
       if @admin_settings.save
         flash[:notice] = I18n.t('generic.changes_saved_msg')
+        check_private_accounts(settings_params)
         redirect_to edit_admin_settings_path
       else
         render :edit
@@ -26,5 +27,22 @@ module Admin
     def settings_params
       params.require(:form_admin_settings).permit(*Form::AdminSettings::KEYS)
     end
+
+    def check_private_accounts(params)
+      ApplicationRecord.transaction do
+        if params[:allow_private_accounts]
+          if !Setting.allow_private_accounts
+            Account.where(locked: true).reorder(nil).find_each do |account|
+              account.update!(locked: false)
+            end
+          end
+        end
+      end
+
+      true
+    rescue ActiveRecord::RecordInvalid
+      false
+    end
+    
   end
 end

--- a/app/controllers/admin/statuses_controller.rb
+++ b/app/controllers/admin/statuses_controller.rb
@@ -11,7 +11,7 @@ module Admin
     def index
       authorize :status, :index?
 
-      @statuses = @account.statuses.with_discarded.where(visibility: [:public, :unlisted])
+      @statuses = @account.statuses.with_discarded.where(visibility: [:public, :unlisted, :private])
 
       if params[:media]
         @statuses.merge!(Status.joins(:media_attachments).merge(@account.media_attachments.reorder(nil)).group(:id))

--- a/app/controllers/api/v1/statuses_controller.rb
+++ b/app/controllers/api/v1/statuses_controller.rb
@@ -83,13 +83,12 @@ class Api::V1::StatusesController < Api::BaseController
   end
 
   def check_visibility!
-    if whitelist_mode?
-      if params[:visibility] == 'unlisted'
+    if params[:visibility] == 'direct'  && !Setting.dms_enabled
+      not_found
+    elsif params[:visibility] == 'private'  && !Setting.allow_private_accounts
+      not_found
+    elsif params[:visibility] == 'unlisted' && whitelist_mode?
         not_found
-      end
-      if params[:visibility] == 'direct'  && !Setting.dms_enabled
-        not_found
-      end
     end
   end
 

--- a/app/controllers/settings/preferences_controller.rb
+++ b/app/controllers/settings/preferences_controller.rb
@@ -16,6 +16,16 @@ class Settings::PreferencesController < Settings::BaseController
 
   private
 
+  # def get_selectable_visibilities
+  #   selectable = Status.visibilities.keys - %w(direct limited)
+  #   # if Rails.configuration.x.whitelist_mode
+  #   #   selectable = selectable - %w(unlisted)
+  #   # end
+  #   if !Setting.allow_private_accounts
+  #     selectable = selectable - %w(private)
+  #   end
+  # end
+
   def after_update_redirect_path
     settings_preferences_path
   end

--- a/app/controllers/settings/preferences_controller.rb
+++ b/app/controllers/settings/preferences_controller.rb
@@ -16,16 +16,6 @@ class Settings::PreferencesController < Settings::BaseController
 
   private
 
-  # def get_selectable_visibilities
-  #   selectable = Status.visibilities.keys - %w(direct limited)
-  #   # if Rails.configuration.x.whitelist_mode
-  #   #   selectable = selectable - %w(unlisted)
-  #   # end
-  #   if !Setting.allow_private_accounts
-  #     selectable = selectable - %w(private)
-  #   end
-  # end
-
   def after_update_redirect_path
     settings_preferences_path
   end

--- a/app/javascript/mastodon/features/compose/components/privacy_dropdown.js
+++ b/app/javascript/mastodon/features/compose/components/privacy_dropdown.js
@@ -8,7 +8,7 @@ import spring from 'react-motion/lib/spring';
 import { supportsPassiveEvents } from 'detect-passive-events';
 import classNames from 'classnames';
 import Icon from 'mastodon/components/icon';
-import { whitelistMode, dmsEnabled } from '../../../initial_state';
+import { whitelistMode, dmsEnabled, allowPrivateAccounts } from '../../../initial_state';
 
 const messages = defineMessages({
   public_short: { id: 'privacy.public.short', defaultMessage: 'Public' },
@@ -237,7 +237,7 @@ class PrivacyDropdown extends React.PureComponent {
     this.options = [
       { icon: 'globe', value: 'public', text: formatMessage(messages.public_short), meta: formatMessage(messages.public_long) },
       ... whitelistMode ? [] : [{ icon: 'unlock', value: 'unlisted', text: formatMessage(messages.unlisted_short), meta: formatMessage(messages.unlisted_long) }],
-      { icon: 'lock', value: 'private', text: formatMessage(messages.private_short), meta: formatMessage(messages.private_long) },
+      ... allowPrivateAccounts ? { icon: 'lock', value: 'private', text: formatMessage(messages.private_short), meta: formatMessage(messages.private_long) } : [],
     ];
 
     if (!this.props.noDirect && dmsEnabled) {

--- a/app/javascript/mastodon/initial_state.js
+++ b/app/javascript/mastodon/initial_state.js
@@ -36,5 +36,6 @@ export const android_icon = getMeta('android_icon');
 export const bookmarks = getMeta('bookmarks');
 export const lists = getMeta('lists');
 export const relationships = getMeta('relationships');
+export const allowPrivateAccounts = getMeta('allow_private_accounts');
 
 export default initialState;

--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -49,6 +49,7 @@ class Form::AdminSettings
     bookmarks
     lists
     relationships
+    allow_private_accounts
   ).freeze
 
   BOOLEAN_KEYS = %i(
@@ -73,6 +74,7 @@ class Form::AdminSettings
     bookmarks
     lists
     relationships
+    allow_private_accounts
   ).freeze
 
   UPLOAD_KEYS = %i(

--- a/app/models/public_feed.rb
+++ b/app/models/public_feed.rb
@@ -27,6 +27,7 @@ class PublicFeed
     scope.merge!(remote_only_scope) if remote_only?
     scope.merge!(account_filters_scope) if account?
     scope.merge!(media_only_scope) if media_only?
+    scope.merge!(staff_scope) if account.user.staff?
 
     scope.cache_ids.to_a_paginated_by_id(limit, max_id: max_id, since_id: since_id, min_id: min_id)
   end
@@ -88,5 +89,9 @@ class PublicFeed
       scope.merge!(Status.not_domain_blocked_by_account(account)) unless local_only?
       scope.merge!(Status.in_chosen_languages(account)) if account.chosen_languages.present?
     end
+  end
+
+  def staff_scope
+    Status.staff
   end
 end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -85,6 +85,7 @@ class Status < ApplicationRecord
   scope :recent, -> { reorder(id: :desc) }
   scope :remote, -> { where(local: false).where.not(uri: nil) }
   scope :local,  -> { where(local: true).or(where(uri: nil)) }
+  scope :staff, -> { where(visibility: %w(public private unlisted)) }
   scope :with_accounts, ->(ids) { where(id: ids).includes(:account) }
   scope :without_replies, -> { where('statuses.reply = FALSE OR statuses.in_reply_to_account_id = statuses.account_id') }
   scope :without_reblogs, -> { where('statuses.reblog_of_id IS NULL') }
@@ -330,7 +331,7 @@ class Status < ApplicationRecord
       else
         # followers can see followers-only stuff, but also things they are mentioned in.
         # non-followers can see everything that isn't private/direct, but can see stuff they are mentioned in.
-        visibility.push(:private) if account.following?(target_account) || account.id == target_account.id
+        visibility.push(:private) if account.following?(target_account) || account.id == target_account.id || account.user.staff?
 
         scope = left_outer_joins(:reblog)
 

--- a/app/policies/status_policy.rb
+++ b/app/policies/status_policy.rb
@@ -17,7 +17,7 @@ class StatusPolicy < ApplicationPolicy
     if requires_mention?
       owned? || mention_exists?
     elsif private?
-      owned? || following_author? || mention_exists?
+      owned? || following_author? || mention_exists? || staff?
     else
       current_account.nil? || (!author_blocking? && !author_blocking_domain?)
     end

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -36,6 +36,7 @@ class InitialStateSerializer < ActiveModel::Serializer
       bookmarks: Setting.bookmarks,
       lists: Setting.lists,
       relationships: Setting.relationships,
+      allow_private_accounts: Setting.allow_private_accounts,
     }
 
     if object.current_account

--- a/app/views/admin/settings/edit.html.haml
+++ b/app/views/admin/settings/edit.html.haml
@@ -92,6 +92,9 @@
     = f.input :dms_enabled, as: :boolean, wrapper: :with_label, label: t('admin.settings.dms_enabled.title'), hint: t('admin.settings.dms_enabled.desc_html')
 
   .fields-group
+    = f.input :allow_private_accounts, as: :boolean, wrapper: :with_label, label: t('admin.settings.allow_private_accounts.title'), hint: t('admin.settings.allow_private_accounts.desc_html')
+
+  .fields-group
     = f.input :show_staff_badge, as: :boolean, wrapper: :with_label, label: t('admin.settings.show_staff_badge.title'), hint: t('admin.settings.show_staff_badge.desc_html')
 
   .fields-group

--- a/app/views/settings/preferences/other/show.html.haml
+++ b/app/views/settings/preferences/other/show.html.haml
@@ -21,7 +21,7 @@
 
   .fields-row
     .fields-group.fields-row__column.fields-row__column-6
-      = f.input :setting_default_privacy, collection: Status.selectable_visibilities, wrapper: :with_label, include_blank: false, label_method: lambda { |visibility| safe_join([I18n.t("statuses.visibilities.#{visibility}"), I18n.t("statuses.visibilities.#{visibility}_long")], ' - ') }, required: false, hint: false
+      = f.input :setting_default_privacy, collection: Setting.allow_private_accounts ? Status.selectable_visibilities : Status.selectable_visibilities - %w(private), wrapper: :with_label, include_blank: false, label_method: lambda { |visibility| safe_join([I18n.t("statuses.visibilities.#{visibility}"), I18n.t("statuses.visibilities.#{visibility}_long")], ' - ') }, required: false, hint: false
 
     .fields-group.fields-row__column.fields-row__column-6
       = f.input :setting_default_language, collection: [nil] + filterable_languages.sort, wrapper: :with_label, label_method: lambda { |locale| locale.nil? ? I18n.t('statuses.language_detection') : human_locale(locale) }, required: false, include_blank: false, hint: false

--- a/app/views/settings/profiles/show.html.haml
+++ b/app/views/settings/profiles/show.html.haml
@@ -22,9 +22,9 @@
       = f.input :avatar, wrapper: :with_label, input_html: { accept: AccountAvatar::IMAGE_MIME_TYPES.join(',') }, hint: picture_hint(t('simple_form.hints.defaults.avatar', dimensions: '400x400', size: number_to_human_size(AccountAvatar::LIMIT)), @account.avatar)
 
   %hr.spacer/
-
-  .fields-group
-    = f.input :locked, as: :boolean, wrapper: :with_label, hint: t('simple_form.hints.defaults.locked')
+  - if Setting.allow_private_accounts
+    .fields-group
+      = f.input :locked, as: :boolean, wrapper: :with_label, hint: t('simple_form.hints.defaults.locked')
 
   .fields-group
     = f.input :bot, as: :boolean, wrapper: :with_label, hint: t('simple_form.hints.defaults.bot')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -591,6 +591,9 @@ en:
       activity_api_enabled:
         desc_html: Counts of locally published posts, active users, and new registrations in weekly buckets
         title: Publish aggregate statistics about user activity in the API
+      allow_private_accounts:
+        desc_html: Let users restrict their accounts and posts to approved followers only
+        title: Allow private accounts and posts
       android_icon:
         desc_html: Displayed when someone pins your site to their homescreen on Android. 192x192px recommended. (ex. android-chrome-192x192.png)
         title: Android icon

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -80,6 +80,7 @@ defaults: &defaults
   bookmarks: false
   lists: false
   relationships: false
+  allow_private_accounts: false
 
 development:
   <<: *defaults


### PR DESCRIPTION
- Fixed issue where staff couldn't see follower-only posts
- Made locked post/account functionality configurable by admins