### PR TITLE
made max post chars configurable through site settings

### DIFF
--- a/.env.vagrant
+++ b/.env.vagrant
@@ -2,7 +2,6 @@ VAGRANT=true
 LOCAL_DOMAIN=mastodon.local
 BIND=0.0.0.0
 DB_HOST=/var/run/postgresql/
-MAX_STATUS_CHARS=3000
 LIMITED_FEDERATION_MODE=true
 
 OIDC_ENABLED=true

--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -50,6 +50,7 @@ class Form::AdminSettings
     lists
     relationships
     allow_private_accounts
+    max_status_chars
   ).freeze
 
   BOOLEAN_KEYS = %i(

--- a/app/validators/status_length_validator.rb
+++ b/app/validators/status_length_validator.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class StatusLengthValidator < ActiveModel::Validator
-  MAX_CHARS = (ENV['MAX_STATUS_CHARS'] || 500).to_i
+  MAX_CHARS = (Setting.max_status_chars || 500).to_i
   URL_PLACEHOLDER = "\1#{'x' * 23}"
 
   def validate(status)

--- a/app/views/admin/settings/edit.html.haml
+++ b/app/views/admin/settings/edit.html.haml
@@ -25,8 +25,11 @@
     .fields-row__column.fields-row__column-6.fields-group
       = f.input :site_contact_email, wrapper: :with_label, label: t('admin.settings.contact_information.email')
 
-  .fields-group
-    = f.input :support_url, wrapper: :with_block_label, label: t('admin.settings.support_url.title'), hint: t('admin.settings.support_url.desc_html')
+  .fields-row
+    .fields-row__column.fields-row__column-6.fields-group
+      = f.input :support_url, wrapper: :with_block_label, label: t('admin.settings.support_url.title'), hint: t('admin.settings.support_url.desc_html')
+    .fields-row__column.fields-row__column-6.fields-group
+      = f.input :max_status_chars, wrapper: :with_block_label, label: t('admin.settings.max_status_chars.title'), hint: t('admin.settings.max_status_chars.desc_html')
 
   .fields-group
     = f.input :site_short_description, wrapper: :with_block_label, as: :text, label: t('admin.settings.site_short_description.title'), hint: t('admin.settings.site_short_description.desc_html', title: site_title), input_html: { rows: 2 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -646,6 +646,9 @@ en:
       mascot:
         desc_html: Displayed on multiple pages. At least 293×205px recommended. When not set, falls back to default mascot
         title: Mascot image
+      max_status_chars:
+        desc_html: Set a custom max character count for posts. Default is 500.
+        title: Max post characters
       non_staff_development:
         desc_html: Allow users who aren't staff to create applications and access the API
         title: Allow users who aren't staff to access the API

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -81,6 +81,7 @@ defaults: &defaults
   lists: false
   relationships: false
   allow_private_accounts: false
+  max_status_chars: ''
 
 development:
   <<: *defaults


### PR DESCRIPTION
Max post chars is now configurable through site settings, not through an environment variable.