### PR TITLE
add post queue; private posts available only when account is locked; fix small DM bug

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -45,7 +45,7 @@ sudo apt-get install \
 # Install rvm
 read RUBY_VERSION < .ruby-version
 
-gpg_command="gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB"
+gpg_command="gpg --keyserver pgp.mit.edu --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB"
 $($gpg_command)
 if [ $? -ne 0 ];then
   echo "GPG command failed, This prevented RVM from installing."

--- a/app/controllers/admin/queued_statuses_controller.rb
+++ b/app/controllers/admin/queued_statuses_controller.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Admin
+  class QueuedStatusesController < BaseController
+    helper_method :current_params
+
+    PER_PAGE = 20
+
+    def index
+      authorize :status, :index?
+
+      @statuses = Status.unscope(where: :pending).where(pending: true)
+
+      @statuses = @statuses.preload(:media_attachments, :mentions).page(params[:page]).per(PER_PAGE)
+      @form     = Form::StatusBatch.new
+    end
+
+    def create
+      authorize :status, :update?
+
+      @form         = Form::StatusBatch.new(form_status_batch_params.merge(current_account: current_account, action: action_from_button))
+      flash[:alert] = I18n.t('admin.statuses.failed_to_execute') unless @form.save
+
+      redirect_to admin_queued_statuses_path(current_params)
+    rescue ActionController::ParameterMissing
+      flash[:alert] = I18n.t('admin.statuses.no_status_selected')
+
+      redirect_to admin_queued_statuses_path(current_params)
+    end
+
+    private
+
+    def form_status_batch_params
+      params.require(:form_status_batch).permit(:action, :email_collection => [:text, :send_email_notification], status_ids: [])
+    end
+
+    def current_params
+      page = (params[:page] || 1).to_i
+
+      {
+        media: params[:media],
+        page: page > 1 && page,
+      }.select { |_, value| value.present? }
+    end
+
+    def action_from_button
+      if params[:nsfw_on]
+        'nsfw_on'
+      elsif params[:delete]
+        'delete'
+      elsif params[:disable_replies]
+        'disable_replies'
+      elsif params[:approve]
+        'approve'
+      end
+    end
+  end
+end
+  

--- a/app/controllers/admin/queued_statuses_controller.rb
+++ b/app/controllers/admin/queued_statuses_controller.rb
@@ -18,7 +18,7 @@ module Admin
     def create
       authorize :status, :update?
 
-      @form         = Form::StatusBatch.new(form_status_batch_params.merge(current_account: current_account, action: action_from_button))
+      @form         = Form::StatusBatch.new(form_status_batch_params.merge(current_account: current_account, action: action_from_button, queue: true))
       flash[:alert] = I18n.t('admin.statuses.failed_to_execute') unless @form.save
 
       redirect_to admin_queued_statuses_path(current_params)

--- a/app/controllers/api/v1/statuses_controller.rb
+++ b/app/controllers/api/v1/statuses_controller.rb
@@ -85,7 +85,7 @@ class Api::V1::StatusesController < Api::BaseController
   def check_visibility!
     if params[:visibility] == 'direct'  && !Setting.dms_enabled
       not_found
-    elsif params[:visibility] == 'private'  && (!current_user.account.locked?)
+    elsif params[:visibility] == 'private'  && !current_user.account.locked?
       not_found
     elsif params[:visibility] == 'unlisted' && whitelist_mode?
         not_found

--- a/app/controllers/api/v1/statuses_controller.rb
+++ b/app/controllers/api/v1/statuses_controller.rb
@@ -85,7 +85,7 @@ class Api::V1::StatusesController < Api::BaseController
   def check_visibility!
     if params[:visibility] == 'direct'  && !Setting.dms_enabled
       not_found
-    elsif params[:visibility] == 'private'  && !Setting.allow_private_accounts
+    elsif params[:visibility] == 'private'  && (!current_user.account.locked?)
       not_found
     elsif params[:visibility] == 'unlisted' && whitelist_mode?
         not_found

--- a/app/javascript/mastodon/actions/compose.js
+++ b/app/javascript/mastodon/actions/compose.js
@@ -158,26 +158,6 @@ export function submitCompose(routerHistory) {
 
       dispatch(insertIntoTagHistory(response.data.tags, status));
       dispatch(submitComposeSuccess({ ...response.data }));
-
-      // To make the app more responsive, immediately push the status
-      // into the columns
-      const insertIfOnline = timelineId => {
-        const timeline = getState().getIn(['timelines', timelineId]);
-
-        if (timeline && timeline.get('items').size > 0 && timeline.getIn(['items', 0]) !== null && timeline.get('online')) {
-          dispatch(updateTimeline(timelineId, { ...response.data }));
-        }
-      };
-
-      if (response.data.visibility !== 'direct') {
-        insertIfOnline('home');
-      }
-
-      if (response.data.in_reply_to_id === null && response.data.visibility === 'public') {
-        insertIfOnline('community');
-        insertIfOnline('public');
-        insertIfOnline(`account:${response.data.account.id}`);
-      }
     }).catch(function (error) {
       dispatch(submitComposeFail(error));
     });

--- a/app/javascript/mastodon/features/compose/components/privacy_dropdown.js
+++ b/app/javascript/mastodon/features/compose/components/privacy_dropdown.js
@@ -8,7 +8,7 @@ import spring from 'react-motion/lib/spring';
 import { supportsPassiveEvents } from 'detect-passive-events';
 import classNames from 'classnames';
 import Icon from 'mastodon/components/icon';
-import { whitelistMode, dmsEnabled, allowPrivateAccounts } from '../../../initial_state';
+import { whitelistMode, dmsEnabled } from '../../../initial_state';
 
 const messages = defineMessages({
   public_short: { id: 'privacy.public.short', defaultMessage: 'Public' },
@@ -161,6 +161,7 @@ class PrivacyDropdown extends React.PureComponent {
     noDirect: PropTypes.bool,
     container: PropTypes.func,
     intl: PropTypes.object.isRequired,
+    accountLocked: PropTypes.bool,
   };
 
   state = {
@@ -237,7 +238,7 @@ class PrivacyDropdown extends React.PureComponent {
     this.options = [
       { icon: 'globe', value: 'public', text: formatMessage(messages.public_short), meta: formatMessage(messages.public_long) },
       ... whitelistMode ? [] : [{ icon: 'unlock', value: 'unlisted', text: formatMessage(messages.unlisted_short), meta: formatMessage(messages.unlisted_long) }],
-      ... allowPrivateAccounts ? { icon: 'lock', value: 'private', text: formatMessage(messages.private_short), meta: formatMessage(messages.private_long) } : [],
+      ... this.props.accountLocked? { icon: 'lock', value: 'private', text: formatMessage(messages.private_short), meta: formatMessage(messages.private_long) } : [],
     ];
 
     if (!this.props.noDirect && dmsEnabled) {

--- a/app/javascript/mastodon/features/compose/containers/privacy_dropdown_container.js
+++ b/app/javascript/mastodon/features/compose/containers/privacy_dropdown_container.js
@@ -3,9 +3,11 @@ import PrivacyDropdown from '../components/privacy_dropdown';
 import { changeComposeVisibility } from '../../../actions/compose';
 import { openModal, closeModal } from '../../../actions/modal';
 import { isUserTouching } from '../../../is_mobile';
+import { me } from '../../../initial_state';
 
 const mapStateToProps = state => ({
   value: state.getIn(['compose', 'privacy']),
+  accountLocked: state.getIn(['accounts', me, 'locked']),
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/app/javascript/mastodon/features/compose/containers/warning_container.js
+++ b/app/javascript/mastodon/features/compose/containers/warning_container.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import Warning from '../components/warning';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import { me } from '../../../initial_state';
+import { statusQueueEnabled, title } from '../../../initial_state';
 
 const buildHashtagRE = () => {
   try {
@@ -31,20 +31,11 @@ const buildHashtagRE = () => {
 const APPROX_HASHTAG_RE = buildHashtagRE();
 
 const mapStateToProps = state => ({
-  needsLockWarning: state.getIn(['compose', 'privacy']) === 'private' && !state.getIn(['accounts', me, 'locked']),
-  hashtagWarning: state.getIn(['compose', 'privacy']) !== 'public' && APPROX_HASHTAG_RE.test(state.getIn(['compose', 'text'])),
   directMessageWarning: state.getIn(['compose', 'privacy']) === 'direct',
+  queueWarning: statusQueueEnabled,
 });
 
-const WarningWrapper = ({ needsLockWarning, hashtagWarning, directMessageWarning }) => {
-  if (needsLockWarning) {
-    return <Warning message={<FormattedMessage id='compose_form.lock_disclaimer' defaultMessage='Your account is not {locked}. Anyone can follow you to view your follower-only posts.' values={{ locked: <a href='/settings/profile'><FormattedMessage id='compose_form.lock_disclaimer.lock' defaultMessage='locked' /></a> }} />} />;
-  }
-
-  if (hashtagWarning) {
-    return <Warning message={<FormattedMessage id='compose_form.hashtag_warning' defaultMessage="This post won't be listed under any hashtag as it is unlisted. Only public posts can be searched by hashtag." />} />;
-  }
-
+const WarningWrapper = ({ directMessageWarning, queueWarning }) => {
   if (directMessageWarning) {
     const message = (
       <span>
@@ -53,6 +44,10 @@ const WarningWrapper = ({ needsLockWarning, hashtagWarning, directMessageWarning
     );
 
     return <Warning message={message} />;
+  }
+  
+  if(queueWarning){
+    return <Warning message={<FormattedMessage id='compose_form.queue_warning' defaultMessage="{title} is currently queuing posts. That means this post won't show up on timelines until it's approved by site staff." values={{ title: <span>{title}</span> }} />} />;
   }
 
   return null;

--- a/app/javascript/mastodon/initial_state.js
+++ b/app/javascript/mastodon/initial_state.js
@@ -36,6 +36,6 @@ export const android_icon = getMeta('android_icon');
 export const bookmarks = getMeta('bookmarks');
 export const lists = getMeta('lists');
 export const relationships = getMeta('relationships');
-export const allowPrivateAccounts = getMeta('allow_private_accounts');
+export const statusQueueEnabled = getMeta('status_queue')
 
 export default initialState;

--- a/app/javascript/mastodon/locales/defaultMessages.json
+++ b/app/javascript/mastodon/locales/defaultMessages.json
@@ -1407,6 +1407,10 @@
       {
         "defaultMessage": "Learn more",
         "id": "compose_form.direct_message_warning_learn_more"
+      },
+      {
+        "defaultMessage": "{title} is currently queuing posts. That means this post won't show up on timelines until it's approved by site staff.",
+        "id": "compose_form.queue_warning"
       }
     ],
     "path": "app/javascript/mastodon/features/compose/containers/warning_container.json"

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -102,6 +102,7 @@
   "compose_form.poll.switch_to_single": "Change poll to allow for a single choice",
   "compose_form.publish": "Post",
   "compose_form.publish_loud": "{publish}!",
+  "compose_form.queue_warning": "{title} is currently queuing posts. That means this post won't show up on timelines until it's approved by site staff.",
   "compose_form.sensitive.hide": "{count, plural, one {Mark media as sensitive} other {Mark media as sensitive}}",
   "compose_form.sensitive.marked": "{count, plural, one {Media is marked as sensitive} other {Media is marked as sensitive}}",
   "compose_form.sensitive.unmarked": "{count, plural, one {Media is not marked as sensitive} other {Media is not marked as sensitive}}",

--- a/app/lib/activitypub/activity.rb
+++ b/app/lib/activitypub/activity.rb
@@ -31,8 +31,11 @@ class ActivityPub::Activity
       notify_about_mentions(status)
   
       # Only continue if the status is supposed to have arrived in real-time.
-      return unless status.within_realtime_window?
-  
+      # Note that if @options[:override_timestamps] isn't set, the status
+      # may have a lower snowflake id than other existing statuses, potentially
+      # "hiding" it from paginated API calls
+      return unless status.override_timestamps || status.within_realtime_window?
+
       distribute_to_followers(status)
     end
 

--- a/app/lib/activitypub/activity/announce.rb
+++ b/app/lib/activitypub/activity/announce.rb
@@ -18,7 +18,6 @@ class ActivityPub::Activity::Announce < ActivityPub::Activity
         reblog: original_status,
         uri: @json['id'],
         created_at: @json['published'],
-        override_timestamps: @options[:override_timestamps],
         visibility: visibility_from_audience
       )
 

--- a/app/lib/activitypub/activity/announce.rb
+++ b/app/lib/activitypub/activity/announce.rb
@@ -18,6 +18,7 @@ class ActivityPub::Activity::Announce < ActivityPub::Activity
         reblog: original_status,
         uri: @json['id'],
         created_at: @json['published'],
+        override_timestamps: @options[:override_timestamps],
         visibility: visibility_from_audience
       )
 

--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -104,6 +104,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
         language: detected_language,
         spoiler_text: converted_object_type? ? '' : (text_from_summary || ''),
         created_at: @object['published'],
+        override_timestamps: @options[:override_timestamps],
         reply: @object['inReplyTo'].present?,
         sensitive: @account.sensitized? || @object['sensitive'] || false,
         visibility: visibility_from_audience,

--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -84,7 +84,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
 
     resolve_thread(@status)
     fetch_replies(@status)
-    distribute(@status)
+    distribute(@status) unless @status.pending
     forward_for_reply
   end
 
@@ -104,7 +104,6 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
         language: detected_language,
         spoiler_text: converted_object_type? ? '' : (text_from_summary || ''),
         created_at: @object['published'],
-        override_timestamps: @options[:override_timestamps],
         reply: @object['inReplyTo'].present?,
         sensitive: @account.sensitized? || @object['sensitive'] || false,
         visibility: visibility_from_audience,

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -164,7 +164,7 @@ class UserMailer < Devise::Mailer
     @resource = user
     @warning  = warning
     @instance = Rails.configuration.x.local_domain
-    @statuses = Status.with_discarded.where(id: status_ids).includes(:account) if status_ids.is_a?(Array)
+    @statuses = Status.unscope(where: :pending).with_discarded.where(id: status_ids).includes(:account) if status_ids.is_a?(Array)
 
     I18n.with_locale(@resource.locale || I18n.default_locale) do
       mail to: @resource.email,

--- a/app/models/account_warning.rb
+++ b/app/models/account_warning.rb
@@ -13,7 +13,7 @@
 #
 
 class AccountWarning < ApplicationRecord
-  enum action: %i(none disable sensitive silence suspend delete disable_replies enable_replies nsfw_on nsfw_off restore), _suffix: :action
+  enum action: %i(none disable sensitive silence suspend delete disable_replies enable_replies nsfw_on nsfw_off restore approve), _suffix: :action
 
   belongs_to :account, inverse_of: :account_warnings
   belongs_to :target_account, class_name: 'Account', inverse_of: :targeted_account_warnings

--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -51,6 +51,7 @@ class Form::AdminSettings
     relationships
     allow_private_accounts
     max_status_chars
+    status_queue
   ).freeze
 
   BOOLEAN_KEYS = %i(
@@ -76,6 +77,7 @@ class Form::AdminSettings
     lists
     relationships
     allow_private_accounts
+    status_queue
   ).freeze
 
   UPLOAD_KEYS = %i(

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -23,6 +23,7 @@
 #  in_reply_to_account_id :bigint(8)
 #  poll_id                :bigint(8)
 #  deleted_at             :datetime
+#  pending                :boolean          default(FALSE), not null
 #
 
 class Status < ApplicationRecord
@@ -37,10 +38,6 @@ class Status < ApplicationRecord
   rate_limit by: :account, family: :statuses
 
   self.discard_column = :deleted_at
-
-  # If `override_timestamps` is set at creation time, Snowflake ID creation
-  # will be based on current time instead of `created_at`
-  attr_accessor :override_timestamps
 
   update_index('statuses#status', :proper)
 
@@ -81,6 +78,7 @@ class Status < ApplicationRecord
   accepts_nested_attributes_for :poll
 
   default_scope { recent.kept }
+  default_scope { where(pending: false) }
 
   scope :recent, -> { reorder(id: :desc) }
   scope :remote, -> { where(local: false).where.not(uri: nil) }
@@ -270,6 +268,7 @@ class Status < ApplicationRecord
   before_validation :set_visibility
   before_validation :set_conversation
   before_validation :set_local
+  before_create :set_pending
 
   after_create :set_poll_id
 
@@ -390,6 +389,11 @@ class Status < ApplicationRecord
     self.visibility = reblog.visibility if reblog? && visibility.nil?
     self.visibility = (account.locked? ? :private : :public) if visibility.nil?
     self.sensitive  = false if sensitive.nil?
+  end
+
+  def set_pending
+    return if direct_visibility?
+    self.pending = Setting.status_queue ? true : false
   end
 
   def set_conversation

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -39,6 +39,10 @@ class Status < ApplicationRecord
 
   self.discard_column = :deleted_at
 
+  # If `override_timestamps` is set at creation time, Snowflake ID creation
+  # will be based on current time instead of `created_at`
+  attr_accessor :override_timestamps
+
   update_index('statuses#status', :proper)
 
   enum visibility: [:public, :unlisted, :private, :direct, :limited], _suffix: :visibility

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -392,7 +392,7 @@ class Status < ApplicationRecord
   end
 
   def set_pending
-    return if direct_visibility?
+    return if direct_visibility? || account.user.staff?
     self.pending = Setting.status_queue ? true : false
   end
 

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -36,7 +36,7 @@ class InitialStateSerializer < ActiveModel::Serializer
       bookmarks: Setting.bookmarks,
       lists: Setting.lists,
       relationships: Setting.relationships,
-      allow_private_accounts: Setting.allow_private_accounts,
+      status_queue: Setting.status_queue,
     }
 
     if object.current_account

--- a/app/services/fan_out_on_write_service.rb
+++ b/app/services/fan_out_on_write_service.rb
@@ -7,7 +7,6 @@ class FanOutOnWriteService < BaseService
     raise Mastodon::RaceConditionError if status.visibility.nil?
 
     if status.direct_visibility?
-      deliver_to_mentioned_followers(status)
       deliver_to_own_conversation(status)
     elsif status.limited_visibility?
       deliver_to_mentioned_followers(status)

--- a/app/views/admin/queued_statuses/index.html.haml
+++ b/app/views/admin/queued_statuses/index.html.haml
@@ -16,6 +16,7 @@
 = form_for(@form, url: admin_queued_statuses_path, html: { class: 'moderation_form' }) do |f|
   = hidden_field_tag :page, params[:page]
   = hidden_field_tag :media, params[:media]
+  = hidden_field_tag :media, params[:queue]
 
   = f.simple_fields_for :email_collection do |email_form|
     .fields-group

--- a/app/views/admin/queued_statuses/index.html.haml
+++ b/app/views/admin/queued_statuses/index.html.haml
@@ -1,0 +1,43 @@
+- content_for :header_tags do
+  = javascript_pack_tag 'admin', async: true, crossorigin: 'anonymous'
+
+- content_for :page_title do
+  = t('admin.status_queue.title')
+
+.filters
+  .filter-subset
+    %strong= t('admin.statuses.media.title')
+    %ul
+      %li= link_to t('admin.statuses.no_media'), admin_queued_statuses_path(current_params.merge(media: nil)), class: !params[:media] && 'selected'
+      %li= link_to t('admin.statuses.with_media'), admin_queued_statuses_path(current_params.merge(media: true)), class: params[:media] && 'selected'
+
+%hr.spacer/
+
+= form_for(@form, url: admin_queued_statuses_path, html: { class: 'moderation_form' }) do |f|
+  = hidden_field_tag :page, params[:page]
+  = hidden_field_tag :media, params[:media]
+
+  = f.simple_fields_for :email_collection do |email_form|
+    .fields-group
+      = email_form.input :send_email_notification, as: :boolean, wrapper: :with_label, :input_html => { :checked => false }, label: t('admin.statuses.email_form.send_email_notification.title'), hint: t('admin.statuses.email_form.send_email_notification.desc_html')
+    
+    %br/
+    .fields-group
+      = email_form.input :text, as: :text, wrapper: :with_block_label, label: t('admin.statuses.email_form.text.title'), hint: t('admin.statuses.email_form.text.desc_html'), required: false
+
+  %hr.spacer/
+
+  .batch-table
+    .batch-table__toolbar
+      %label.batch-table__toolbar__select.batch-checkbox-all
+        = check_box_tag :batch_checkbox_all, nil, false
+      .batch-table__toolbar__actions
+        = f.button safe_join([fa_icon('eye-slash'), t('admin.statuses.batch.nsfw_on')]), name: :nsfw_on, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
+        - if Setting.disable_replies
+          = f.button safe_join([fa_icon('comments-o'), t('admin.statuses.batch.disable_replies')]), name: :disable_replies, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
+        = f.button safe_join([fa_icon('trash'), t('admin.statuses.batch.delete')]), name: :delete, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
+        = f.button safe_join([fa_icon('check'), t('admin.statuses.batch.approve')]), name: :approve, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
+    .batch-table__body
+      = render partial: 'admin/reports/status', collection: @statuses, locals: { f: f }
+
+= paginate @statuses

--- a/app/views/admin/reports/_status.html.haml
+++ b/app/views/admin/reports/_status.html.haml
@@ -22,12 +22,17 @@
         = react_component :media_gallery, height: 343, sensitive: status.proper.sensitive?, visible: false, media: status.proper.media_attachments.map { |a| ActiveModelSerializers::SerializableResource.new(a, serializer: REST::MediaAttachmentSerializer).as_json }
 
     .detailed-status__meta
+      = admin_account_inline_link_to(status.account)
+      ·
       = link_to ActivityPub::TagManager.instance.url_for(status), class: 'detailed-status__datetime', target: stream_link_target, rel: 'noopener noreferrer' do
         %time.formatted{ datetime: status.created_at.iso8601, title: l(status.created_at) }= l(status.created_at)
       - if status.discarded?
         ·
         %span.negative-hint= t('admin.statuses.deleted')
       ·
+      - if status.pending
+        %span.warning-hint= t('admin.status_queue.pending')
+        ·
       - if status.reblog?
         = fa_icon('retweet fw')
         = t('statuses.boosted_from_html', acct_link: admin_account_inline_link_to(status.proper.account))

--- a/app/views/admin/settings/edit.html.haml
+++ b/app/views/admin/settings/edit.html.haml
@@ -98,6 +98,9 @@
     = f.input :allow_private_accounts, as: :boolean, wrapper: :with_label, label: t('admin.settings.allow_private_accounts.title'), hint: t('admin.settings.allow_private_accounts.desc_html')
 
   .fields-group
+    = f.input :status_queue, as: :boolean, wrapper: :with_label, label: t('admin.settings.status_queue.title'), hint: t('admin.settings.status_queue.desc_html')
+
+  .fields-group
     = f.input :show_staff_badge, as: :boolean, wrapper: :with_label, label: t('admin.settings.show_staff_badge.title'), hint: t('admin.settings.show_staff_badge.desc_html')
 
   .fields-group

--- a/app/views/settings/preferences/other/show.html.haml
+++ b/app/views/settings/preferences/other/show.html.haml
@@ -21,7 +21,7 @@
 
   .fields-row
     .fields-group.fields-row__column.fields-row__column-6
-      = f.input :setting_default_privacy, collection: Setting.allow_private_accounts ? Status.selectable_visibilities : Status.selectable_visibilities - %w(private), wrapper: :with_label, include_blank: false, label_method: lambda { |visibility| safe_join([I18n.t("statuses.visibilities.#{visibility}"), I18n.t("statuses.visibilities.#{visibility}_long")], ' - ') }, required: false, hint: false
+      = f.input :setting_default_privacy, collection: current_user.account.locked? ? Status.selectable_visibilities : Status.selectable_visibilities - %w(private), wrapper: :with_label, include_blank: false, label_method: lambda { |visibility| safe_join([I18n.t("statuses.visibilities.#{visibility}"), I18n.t("statuses.visibilities.#{visibility}_long")], ' - ') }, required: false, hint: false
 
     .fields-group.fields-row__column.fields-row__column-6
       = f.input :setting_default_language, collection: [nil] + filterable_languages.sort, wrapper: :with_label, label_method: lambda { |locale| locale.nil? ? I18n.t('statuses.language_detection') : human_locale(locale) }, required: false, include_blank: false, hint: false

--- a/app/workers/activitypub/fetch_replies_worker.rb
+++ b/app/workers/activitypub/fetch_replies_worker.rb
@@ -7,7 +7,7 @@ class ActivityPub::FetchRepliesWorker
   sidekiq_options queue: 'pull', retry: 3
 
   def perform(parent_status_id, replies_uri)
-    ActivityPub::FetchRepliesService.new.call(Status.find(parent_status_id), replies_uri)
+    ActivityPub::FetchRepliesService.new.call(Status.unscope(where: :pending).find(parent_status_id), replies_uri)
   rescue ActiveRecord::RecordNotFound
     true
   end

--- a/app/workers/activitypub/processing_worker.rb
+++ b/app/workers/activitypub/processing_worker.rb
@@ -6,7 +6,7 @@ class ActivityPub::ProcessingWorker
   sidekiq_options backtrace: true, retry: 8
 
   def perform(account_id, body, delivered_to_account_id = nil)
-    ActivityPub::ProcessCollectionService.new.call(body, Account.find(account_id), override_timestamps: true, delivered_to_account_id: delivered_to_account_id, delivery: true)
+    ActivityPub::ProcessCollectionService.new.call(body, Account.find(account_id), delivered_to_account_id: delivered_to_account_id, delivery: true)
   rescue ActiveRecord::RecordInvalid => e
     Rails.logger.debug "Error processing incoming ActivityPub object: #{e}"
   end

--- a/app/workers/activitypub/processing_worker.rb
+++ b/app/workers/activitypub/processing_worker.rb
@@ -6,7 +6,7 @@ class ActivityPub::ProcessingWorker
   sidekiq_options backtrace: true, retry: 8
 
   def perform(account_id, body, delivered_to_account_id = nil)
-    ActivityPub::ProcessCollectionService.new.call(body, Account.find(account_id), delivered_to_account_id: delivered_to_account_id, delivery: true)
+    ActivityPub::ProcessCollectionService.new.call(body, Account.find(account_id), override_timestamps: true, delivered_to_account_id: delivered_to_account_id, delivery: true)
   rescue ActiveRecord::RecordInvalid => e
     Rails.logger.debug "Error processing incoming ActivityPub object: #{e}"
   end

--- a/app/workers/thread_resolve_worker.rb
+++ b/app/workers/thread_resolve_worker.rb
@@ -7,7 +7,7 @@ class ThreadResolveWorker
   sidekiq_options queue: 'pull', retry: 3
 
   def perform(child_status_id, parent_url)
-    child_status  = Status.find(child_status_id)
+    child_status  = Status.unscope(where: :pending).find(child_status_id)
     parent_status = FetchRemoteStatusService.new.call(parent_url)
 
     return if parent_status.nil?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -711,6 +711,9 @@ en:
         desc_html: You can write your own privacy policy, terms of service or other legalese. You can use HTML tags
         title: Custom terms of service
       site_title: Server name
+      status_queue: 
+        desc_html: All posts will be queued pending staff approval.
+        title: Queue posts
       support_url: 
         desc_html: Displayed in the link footer. Provide a URL where people can go to help support your site. The appropriate HTTP prefix is required.
         title: Link to support
@@ -733,9 +736,13 @@ en:
     site_uploads:
       delete: Delete uploaded file
       destroyed_msg: Site upload successfully deleted!
+    status_queue:
+      title: Post queue
+      pending: Pending
     statuses:
       back_to_account: Back to account page
       batch:
+        approve: Approve
         delete: Delete
         disable_replies: Disable replies
         enable_replies: Enable replies
@@ -1484,6 +1491,7 @@ en:
       title: Sign in attempt
     warning:
       explanation:
+        approve: Your post has been approved.
         delete: Your post has been deleted.
         disable: You can no longer login to your account or use it in any other way, but your profile and other data remains intact.
         disable_replies: Replies have been turned off for your post. No one will be able to reply to your original post or any existing replies.
@@ -1498,6 +1506,7 @@ en:
       review_server_policies: Review server policies
       statuses: 'Specifically, for:'
       subject:
+        approve: Your post has been approved
         delete: Your post has been deleted
         disable: Your account %{acct} has been frozen
         disable_replies: Replies have been turned off for your post
@@ -1510,6 +1519,7 @@ en:
         silence: Your account %{acct} has been limited
         suspend: Your account %{acct} has been suspended
       title:
+        approve: Post approved
         delete: Post deleted
         disable: Account frozen
         disable_replies: Replies disabled for your post

--- a/config/navigation.rb
+++ b/config/navigation.rb
@@ -36,6 +36,7 @@ SimpleNavigation::Configuration.run do |navigation|
     n.item :moderation, safe_join([fa_icon('gavel fw'), t('moderation.title')]), admin_reports_url, if: proc { current_user.staff? } do |s|
       s.item :action_logs, safe_join([fa_icon('bars fw'), t('admin.action_logs.title')]), admin_action_logs_url
       s.item :reports, safe_join([fa_icon('flag fw'), t('admin.reports.title')]), admin_reports_url, highlights_on: %r{/admin/reports}
+      s.item :status_queue, safe_join([fa_icon('archive fw'), t('admin.status_queue.title')]), admin_queued_statuses_url, highlights_on: %r{/admin/queued_statuses}
       s.item :accounts, safe_join([fa_icon('users fw'), t('admin.accounts.title')]), admin_accounts_url, highlights_on: %r{/admin/accounts|/admin/pending_accounts}
       s.item :invites, safe_join([fa_icon('user-plus fw'), t('admin.invites.title')]), admin_invites_path
       s.item :tags, safe_join([fa_icon('hashtag fw'), t('admin.tags.title')]), admin_tags_path, highlights_on: %r{/admin/tags}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -308,6 +308,7 @@ Rails.application.routes.draw do
     end
 
     resources :featured_topics, only: [:index, :create, :destroy]
+    resources :queued_statuses, only: [:index, :create]
   end
 
   get '/admin', to: redirect('/admin/dashboard', status: 302)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -81,7 +81,8 @@ defaults: &defaults
   lists: false
   relationships: false
   allow_private_accounts: false
-  max_status_chars: ''
+  max_status_chars: '500'
+  status_queue: false
 
 development:
   <<: *defaults

--- a/db/migrate/20210623172216_add_pending_to_statuses.rb
+++ b/db/migrate/20210623172216_add_pending_to_statuses.rb
@@ -1,0 +1,14 @@
+require Rails.root.join('lib', 'mastodon', 'migration_helpers')
+class AddPendingToStatuses < ActiveRecord::Migration[6.1]
+  include Mastodon::MigrationHelpers
+
+  disable_ddl_transaction!
+
+  def up
+    safety_assured { add_column_with_default :statuses, :pending, :boolean, default: false, allow_null: false }
+  end
+
+  def down
+    remove_column :statuses, :pending
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_07_001928) do
+ActiveRecord::Schema.define(version: 2021_06_23_172216) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -113,6 +113,15 @@ ActiveRecord::Schema.define(version: 2021_05_07_001928) do
     t.datetime "last_status_at"
     t.integer "lock_version", default: 0, null: false
     t.index ["account_id"], name: "index_account_stats_on_account_id", unique: true
+  end
+
+  create_table "account_tag_stats", force: :cascade do |t|
+    t.bigint "tag_id", null: false
+    t.bigint "accounts_count", default: 0, null: false
+    t.boolean "hidden", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["tag_id"], name: "index_account_tag_stats_on_tag_id", unique: true
   end
 
   create_table "account_warning_presets", force: :cascade do |t|
@@ -413,7 +422,7 @@ ActiveRecord::Schema.define(version: 2021_05_07_001928) do
     t.datetime "updated_at", null: false
     t.index ["tag_id"], name: "index_featured_topics_on_tag_id"
   end
-  
+
   create_table "follow_recommendation_suppressions", force: :cascade do |t|
     t.bigint "account_id", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -827,6 +836,7 @@ ActiveRecord::Schema.define(version: 2021_05_07_001928) do
     t.bigint "in_reply_to_account_id"
     t.bigint "poll_id"
     t.datetime "deleted_at"
+    t.boolean "pending", default: false, null: false
     t.index ["account_id", "id", "visibility", "updated_at"], name: "index_statuses_20190820", order: { id: :desc }, where: "(deleted_at IS NULL)"
     t.index ["id", "account_id"], name: "index_statuses_local_20190824", order: { id: :desc }, where: "((local OR (uri IS NULL)) AND (deleted_at IS NULL) AND (visibility = 0) AND (reblog_of_id IS NULL) AND ((NOT reply) OR (in_reply_to_account_id = account_id)))"
     t.index ["id", "account_id"], name: "index_statuses_public_20200119", order: { id: :desc }, where: "((deleted_at IS NULL) AND (visibility = 0) AND (reblog_of_id IS NULL) AND ((NOT reply) OR (in_reply_to_account_id = account_id)))"

--- a/lib/mastodon/snowflake.rb
+++ b/lib/mastodon/snowflake.rb
@@ -7,7 +7,7 @@ module Mastodon::Snowflake
     def self.around_create(record)
       now = Time.now.utc
 
-      if record.created_at.nil? || record.created_at >= now || record.created_at == record.updated_at
+      if record.created_at.nil? || record.created_at >= now || record.created_at == record.updated_at || record.override_timestamps
         yield
       else
         record.id = Mastodon::Snowflake.id_at(record.created_at)

--- a/lib/mastodon/snowflake.rb
+++ b/lib/mastodon/snowflake.rb
@@ -7,7 +7,7 @@ module Mastodon::Snowflake
     def self.around_create(record)
       now = Time.now.utc
 
-      if record.created_at.nil? || record.created_at >= now || record.created_at == record.updated_at || record.override_timestamps
+      if record.created_at.nil? || record.created_at >= now || record.created_at == record.updated_at
         yield
       else
         record.id = Mastodon::Snowflake.id_at(record.created_at)


### PR DESCRIPTION
- Added a post queue that admins can turn on and off. All posts submitted while the queue is on must be approved by site staff before they appear on timelines.
- Made private posts available only when an account is locked. This is more intuitive than the previous system where a user could make private posts even when anyone could follow them.
- Small DM bug fix where DMs were showing up in the home timeline of the recipient.