### PR TITLE
Sitewide RSS

### DIFF
--- a/app/controllers/api/v1/timelines/public_controller.rb
+++ b/app/controllers/api/v1/timelines/public_controller.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class Api::V1::Timelines::PublicController < Api::BaseController
+  skip_before_action :require_authenticated_user!
   before_action :require_user!, only: [:show], if: :require_auth?
-  before_action :check_local!
   after_action :insert_pagination_headers, unless: -> { @statuses.empty? }
 
   def show
@@ -14,10 +14,6 @@ class Api::V1::Timelines::PublicController < Api::BaseController
 
   def require_auth?
     !Setting.timeline_preview
-  end
-
-  def check_local!
-    return not_found if completely_siloed? && (!params.has_key?(:local) || params[:local] == "false")
   end
 
   def load_statuses

--- a/app/controllers/oauth/authorizations_controller.rb
+++ b/app/controllers/oauth/authorizations_controller.rb
@@ -35,6 +35,6 @@ class Oauth::AuthorizationsController < Doorkeeper::AuthorizationsController
   end
 
   def check_staff!
-    return not_found unless current_user.staff? || Setting.non_staff_development
+    return not_found unless current_user&.staff? || Setting.non_staff_development
   end
 end

--- a/app/controllers/public_timelines_controller.rb
+++ b/app/controllers/public_timelines_controller.rb
@@ -3,17 +3,31 @@
 class PublicTimelinesController < ApplicationController
   layout 'public'
 
-  before_action :authenticate_user!, if: :whitelist_mode?
+  PAGE_SIZE     = 20
+
+  before_action :authenticate_user!, if: -> { !Setting.timeline_preview }
   before_action :require_enabled!
   before_action :set_body_classes
   before_action :set_instance_presenter
+  before_action :set_statuses
 
-  def show; end
+  def show 
+    respond_to do |format|
+      format.html do
+        expires_in 0, public: true
+      end
+
+      format.rss do
+        expires_in 0, public: true
+        render xml: RSS::PublicTimelineSerializer.render(@statuses)
+      end
+    end
+  end
 
   private
 
   def require_enabled!
-    not_found unless Setting.timeline_preview
+    not_found unless Setting.timeline_preview || current_user&.staff?
   end
 
   def set_body_classes
@@ -22,5 +36,20 @@ class PublicTimelinesController < ApplicationController
 
   def set_instance_presenter
     @instance_presenter = InstancePresenter.new
+  end
+
+  def set_statuses
+    case request.format&.to_sym
+    when :rss
+      @statuses = cache_collection(public_statuses, Status)
+    end
+  end
+
+  def public_statuses
+    public_feed.get(PAGE_SIZE)
+  end
+
+  def public_feed
+    PublicFeed.new(nil, local: true)
   end
 end

--- a/app/models/public_feed.rb
+++ b/app/models/public_feed.rb
@@ -27,7 +27,7 @@ class PublicFeed
     scope.merge!(remote_only_scope) if remote_only?
     scope.merge!(account_filters_scope) if account?
     scope.merge!(media_only_scope) if media_only?
-    scope.merge!(staff_scope) if account.user.staff?
+    scope.merge!(staff_scope) if account? && account.user.staff?
 
     scope.cache_ids.to_a_paginated_by_id(limit, max_id: max_id, since_id: since_id, min_id: min_id)
   end

--- a/app/serializers/rss/public_timeline_serializer.rb
+++ b/app/serializers/rss/public_timeline_serializer.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class RSS::PublicTimelineSerializer < RSS::Serializer
+    include ActionView::Helpers::NumberHelper
+    include RoutingHelper
+  
+    def render(statuses)
+      builder = RSSBuilder.new
+  
+      builder.title("#{Setting.site_title}")
+             .description(I18n.t('about.about_public_timeline_html', title: Setting.site_title))
+  
+      render_statuses(builder, statuses)
+  
+      builder.to_xml
+    end
+  
+    def self.render(statuses)
+      new.render(statuses)
+    end
+  end

--- a/app/views/admin/settings/edit.html.haml
+++ b/app/views/admin/settings/edit.html.haml
@@ -73,10 +73,10 @@
 
   %hr.spacer/
 
+  .fields-group
+    = f.input :timeline_preview, as: :boolean, wrapper: :with_label, label: t('admin.settings.timeline_preview.title'), hint: t('admin.settings.timeline_preview.desc_html')
+  
   - unless whitelist_mode?
-    .fields-group
-      = f.input :timeline_preview, as: :boolean, wrapper: :with_label, label: t('admin.settings.timeline_preview.title'), hint: t('admin.settings.timeline_preview.desc_html')
-
     .fields-group
       = f.input :show_known_fediverse_at_about_page, as: :boolean, wrapper: :with_label, label: t('admin.settings.show_known_fediverse_at_about_page.title'), hint: t('admin.settings.show_known_fediverse_at_about_page.desc_html')
 

--- a/app/views/public_timelines/show.html.haml
+++ b/app/views/public_timelines/show.html.haml
@@ -3,6 +3,8 @@
 
 - content_for :header_tags do
   %meta{ name: 'robots', content: 'noindex' }/
+  %link{ rel: 'alternate', type: 'application/rss+xml', href: public_timeline_url(format: 'rss') }/
+  
   = javascript_pack_tag 'about', crossorigin: 'anonymous'
 
 .page-header

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,6 +3,7 @@ en:
   about:
     about_hashtag_html: These are public posts tagged with <strong>#%{hashtag}</strong>. You can interact with them if you have an account anywhere in the fediverse.
     about_mastodon_html: '%{title} is adapted from Mastodon, a social network based on open web protocols, free, open-source software, ethical design, and decentralization.'
+    about_public_timeline_html: These are public posts from %{title}
     about_this: About
     active_count_after: active
     active_footnote: Monthly Active Users (MAU)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -14,7 +14,7 @@ defaults: &defaults
   closed_registrations_message: ''
   open_deletion: true
   min_invite_role: 'admin'
-  timeline_preview: true
+  timeline_preview: false
   show_staff_badge: true
   default_sensitive: false
   hide_network: false


### PR DESCRIPTION
- Added RSS for local timeline accessible at example.social/public.rss
- Made /public always available to staff
- Made unauthenticated public timeline preview configurable in limited federation mode